### PR TITLE
Attributing UTF-16 INF files as text but with eol=LF to avoid corruption

### DIFF
--- a/audio/sysvad/.gitattributes
+++ b/audio/sysvad/.gitattributes
@@ -1,1 +1,3 @@
-tabletaudiosample.inf text eol=lf 
+tabletaudiosample.inf text eol=lf
+phoneaudiosample.inf text eol=lf
+

--- a/audio/sysvad/.gitattributes
+++ b/audio/sysvad/.gitattributes
@@ -1,0 +1,1 @@
+tabletaudiosample.inf text eol=lf 

--- a/avscamera/sys/.gitattributes
+++ b/avscamera/sys/.gitattributes
@@ -1,0 +1,1 @@
+avscamera.inf text eol=lf 

--- a/network/ndis/netvmini/6x/60/.gitattributes
+++ b/network/ndis/netvmini/6x/60/.gitattributes
@@ -1,0 +1,1 @@
+netvmini60.inf text eol=lf 

--- a/network/ndis/netvmini/6x/620/.gitattributes
+++ b/network/ndis/netvmini/6x/620/.gitattributes
@@ -1,0 +1,1 @@
+netvmini620.inf text eol=lf 

--- a/network/ndis/netvmini/6x/630/.gitattributes
+++ b/network/ndis/netvmini/6x/630/.gitattributes
@@ -1,0 +1,1 @@
+netvmini630.inf text eol=lf 

--- a/storage/class/cdrom/src/.gitattributes
+++ b/storage/class/cdrom/src/.gitattributes
@@ -1,0 +1,1 @@
+cdrom.inf text eol=lf 

--- a/storage/miniports/lsi_u3/src/.gitattributes
+++ b/storage/miniports/lsi_u3/src/.gitattributes
@@ -1,0 +1,1 @@
+lsi_u3.inf text eol=lf 

--- a/storage/msdsm/src/.gitattributes
+++ b/storage/msdsm/src/.gitattributes
@@ -1,0 +1,1 @@
+SampleDSM.inf text eol=lf 

--- a/video/KMDOD/Sample/.gitattributes
+++ b/video/KMDOD/Sample/.gitattributes
@@ -1,0 +1,1 @@
+sampledisplay.inf text eol=lf 


### PR DESCRIPTION
Some of our INF files are Unicode encoded.  Since we have a default rule that all INF files are text files that should use CRLF normalization on checkout, these files become corrupted.

To avoid corruption, we have created local exceptions for these specific files.  These Unicode INF files are attributed as text but with LF only normalization which will cause these files to remain untouched and not corrupted on checkout.
