### PR TITLE
Update ecdisp.c to fix HIDP_SET_USAGE_VALUE_ARRAY

### DIFF
--- a/hid/hclient/ecdisp.c
+++ b/hid/hclient/ecdisp.c
@@ -2643,7 +2643,6 @@ RoutineDescription:
                                                  &params -> ListLength);
         free(params -> szListString);
         params->szListString = NULL;
-        params->ListLength = 0;
 
         if (!ExecuteStatus) 
         {


### PR DESCRIPTION
The HIDP_SET_USAGE_VALUE_ARRAY case does not work because the ListLength is hardcoded to 0. Removing this line seems to make it work.