### PR TITLE
Update hid\hclient

### DIFF
--- a/hid/hclient/ecdisp.c
+++ b/hid/hclient/ecdisp.c
@@ -2643,7 +2643,6 @@ RoutineDescription:
                                                  &params -> ListLength);
         free(params -> szListString);
         params->szListString = NULL;
-        params->ListLength = 0;
 
         if (!ExecuteStatus) 
         {

--- a/hid/hclient/hclient.c
+++ b/hid/hclient/hclient.c
@@ -3700,6 +3700,8 @@ AsynchReadThreadProc(
     BOOL    readStatus;
     DWORD   waitStatus;
     ULONG   numReadsDone;
+    OVERLAPPED overlap;
+    DWORD bytesTransferred;
     
     //
     // Create the completion event to send to the the OverlappedRead routine
@@ -3743,7 +3745,7 @@ AsynchReadThreadProc(
         //  exit
         //
 
-        readStatus = ReadOverlapped( Context -> HidDevice, completionEvent );
+        readStatus = ReadOverlapped( Context -> HidDevice, completionEvent, &overlap );
 
     
         if (!readStatus) 
@@ -3761,11 +3763,13 @@ AsynchReadThreadProc(
 
             //
             // If completionEvent was signaled, then a read just completed
-            //   so let's leave this loop and process the data
+            //   so let's get the status and leave this loop and process the data
             //
             
             if ( WAIT_OBJECT_0 == waitStatus)
             { 
+                readStatus = GetOverlappedResult(Context->HidDevice->HidDevice, &overlap, &bytesTransferred, TRUE);
+                
                 break;
             }
         }
@@ -3804,7 +3808,8 @@ AsynchReadThreadProc(
                 CLM_PrintInputReport(Context -> HidDevice);
             }
         }
-    } while ( !Context -> TerminateThread &&
+    } while ( readStatus &&
+              !Context -> TerminateThread &&
               (INFINITE_READS == Context -> NumberOfReads || 
                numReadsDone < Context -> NumberOfReads));
 

--- a/hid/hclient/hid.h
+++ b/hid/hclient/hid.h
@@ -158,7 +158,8 @@ Read (
 BOOLEAN
 ReadOverlapped (
     PHID_DEVICE     HidDevice,
-    HANDLE          CompletionEvent
+    HANDLE          CompletionEvent,
+    LPOVERLAPPED    overlap
    );
    
 BOOLEAN


### PR DESCRIPTION
hid\hclient has two issues that are fixed with these changes:

1. Extended Client Call HidP_SetUsageValueArray currently does nothing because its ListLength is hardcoded to 0

2. Continuous Asynchronous Reads no longer infinitely loops if a device returns a non-success code on an asynchronous read.