### PR TITLE
Update hid\hclient

### DIFF
--- a/hid/hclient/ecdisp.c
+++ b/hid/hclient/ecdisp.c
@@ -2643,7 +2643,6 @@ RoutineDescription:
                                                  &params -> ListLength);
         free(params -> szListString);
         params->szListString = NULL;
-        params->ListLength = 0;
 
         if (!ExecuteStatus) 
         {

--- a/hid/hclient/hid.h
+++ b/hid/hclient/hid.h
@@ -158,7 +158,8 @@ Read (
 BOOLEAN
 ReadOverlapped (
     PHID_DEVICE     HidDevice,
-    HANDLE          CompletionEvent
+    HANDLE          CompletionEvent,
+    LPOVERLAPPED    overlap
    );
    
 BOOLEAN

--- a/hid/hclient/report.c
+++ b/hid/hclient/report.c
@@ -64,7 +64,8 @@ Done:
 BOOLEAN
 ReadOverlapped (
     PHID_DEVICE     HidDevice,
-    HANDLE          CompletionEvent
+    HANDLE          CompletionEvent,
+    LPOVERLAPPED    overlap
    )
 /*++
 RoutineDescription:
@@ -72,7 +73,6 @@ RoutineDescription:
    into the InputData array.
 --*/
 {
-    static OVERLAPPED  overlap;
     DWORD       bytesRead;
     BOOL        readStatus;
 
@@ -81,9 +81,9 @@ RoutineDescription:
     //  to use for signalling the completion of the Read
     */
 
-    memset(&overlap, 0, sizeof(OVERLAPPED));
+    memset(overlap, 0, sizeof(OVERLAPPED));
     
-    overlap.hEvent = CompletionEvent;
+    overlap->hEvent = CompletionEvent;
     
     /*
     // Execute the read call saving the return code to determine how to 
@@ -94,7 +94,7 @@ RoutineDescription:
                             HidDevice -> InputReportBuffer,
                             HidDevice -> Caps.InputReportByteLength,
                             &bytesRead,
-                            &overlap);
+                            overlap);
                           
     /*
     // If the readStatus is FALSE, then one of two cases occurred.  


### PR DESCRIPTION
hid\hclient has two issues that are fixed with these changes:
1. Extended Client Call HidP_SetUsageValueArray currently does nothing because its ListLength is hardcoded to 0
2. Continuous Asynchronous Reads currently infinitely loops if a device returns a non-success code on an asynchronous read. This is especially bad for removable devices as the framework returns all asynchronous failure codes when they are removed.
