### PR TITLE
Added device IO control support for Windows 10

### DIFF
--- a/storage/ramdisk/src/ramdisk.h
+++ b/storage/ramdisk/src/ramdisk.h
@@ -23,6 +23,7 @@ Environment:
 
 #include <ntddk.h>
 #include <ntdddisk.h>
+#include <mountmgr.h>
 
 #pragma warning(default:4201)
 


### PR DESCRIPTION
Added support for the following device IO control codes:

- IOCTL_STORAGE_QUERY_PROPERTY
- IOCTL_DISK_GET_LENGTH_INFO
- IOCTL_MOUNTDEV_QUERY_DEVICE_NAME

Issues addressed: #49 and #44 
