### PR TITLE
Fix NULL-terminating device name when writing to DEVICEMAP/SERIALCOMM

### DIFF
--- a/serial/serial/pnp.c
+++ b/serial/serial/pnp.c
@@ -1987,7 +1987,7 @@ Return Value:
                                    PDevExt->DeviceName.Buffer,
                                    REG_SZ,
                                    pRegName,
-                                   nameSize);
+                                   nameSize + sizeof(WCHAR));
 
     if (!NT_SUCCESS(status)) {
 


### PR DESCRIPTION
fix the issue that user cannot open settings of serial port when using HyperTerminal under Windows XP.