### PR TITLE
added unicode support for devcon

### DIFF
--- a/setup/devcon/cmds.cpp
+++ b/setup/devcon/cmds.cpp
@@ -102,7 +102,7 @@ Return Value:
         for(dispIndex = 0;DispatchTable[dispIndex].cmd;dispIndex++) {
             if(DispatchTable[dispIndex].shortHelp) {
                 FormatToStream(stdout,DispatchTable[dispIndex].shortHelp,DispatchTable[dispIndex].cmd);
-                fputs("\n",stdout);
+                _fputts(TEXT("\n"), stdout);
             }
         }
     }

--- a/setup/devcon/devcon.cpp
+++ b/setup/devcon/devcon.cpp
@@ -14,6 +14,8 @@ Abstract:
 --*/
 
 #include "devcon.h"
+#include <io.h>
+#include <fcntl.h>
 
 struct IdEntry {
     LPCTSTR String;     // string looking for
@@ -99,7 +101,7 @@ Return Value:
     int c;
 
     for(c=0;c<pad;c++) {
-        fputs("    ",stdout);
+        _fputts(TEXT("    "), stdout);
     }
 }
 
@@ -1076,6 +1078,12 @@ Return Value:
     // -r            - auto reboot
     // -f            - force operation
     //
+
+#ifdef UNICODE
+    _setmode(_fileno(stdout), _O_WTEXT);
+    _setmode(_fileno(stderr), _O_WTEXT);
+#endif
+
     baseName = _tcsrchr(argv[0],TEXT('\\'));
     if(!baseName) {
         baseName = argv[0];


### PR DESCRIPTION
Proposed changes because the output of the devcon for the russian version of windows was uninformative. For example, the output of "devcon.exe find usb\\*" command was as follows:

> USB\ROOT_HUB\4&1C7C1FAE&0                                   : ???????? USB-????????????
> USB\ROOT_HUB\4&3A448A3B&0                                   : ???????? USB-????????????
> USB\VID_09DA&PID_9090&MI_00\6&2FEDCB8B&0&0000               : USB-?????????? ?????
> 3 matching device(s) found.


