### PR TITLE
Added metadata to README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!---
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=616507
+--->
+
 # Driver samples for Windows 10
 These are the official Microsoft Windows Driver Kit (WDK) team driver code samples for Windows 10. They provide a foundation for Universal Windows driver support of all hardware form factors, from phones to desktop PCs. Use these samples with Visual Studio 2015 and Windows Driver Kit (WDK) 10.
 

--- a/audio/sysvad/README.md
+++ b/audio/sysvad/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: SysVAD Virtual Audio Device Driver Sample
+    platform: WDM
+    language: cpp
+    category: Audio
+    description: The Microsoft SysVAD Virtual Audio Device Driver (SYSVAD) shows how to develop a WDM audio driver that exposes support for multiple audio devices.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620183
+--->
+
 SysVAD Virtual Audio Device Driver Sample
 ========================================
 

--- a/avstream/avscamera/README.md
+++ b/avstream/avscamera/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: AvsCamera - AVStream Camera Sample Driver
+    platform: WDM
+    language: cpp
+    category: Camera AVStream
+    description: Provides a pin-centric AVStream capture driver for a simulated front and back camera that performs simulated captures at 320x240 or 640x480 in RGB24, RGB32, YUY2 and NV12 formats at various frame rates.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620184
+--->
+
 AvsCamera: AVStream Camera Sample Driver 
 ========================================
 The AvsCamera sample provides a pin-centric AVStream capture driver for a simulated front and back camera. The driver performs simulated captures at 320x240 or 640x480 in RGB24, RGB32, YUY2 and NV12 formats at various frame rates. The purpose of the sample is to demonstrate how to write a fully functional AVStream camera driver. 

--- a/avstream/avshws/README.md
+++ b/avstream/avshws/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: AVStream simulated hardware sample driver (Avshws)
+    platform: WDM
+    language: cpp
+    category: Camera
+    description: A simulated hardware sample driver providing a pin-centric capture driver to simulate AV capture hardware.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620185
+--->
+
 AVStream simulated hardware sample driver (Avshws)
 ==================================================
 

--- a/avstream/avssamp/README.md
+++ b/avstream/avssamp/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: AVStream filter-centric simulated capture sample driver (Avssamp)
+    platform: WDM
+    language: cpp
+    category: Camera
+    description: An AVStream filter-centric simulated capture sample driver with functional audio.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620186
+--->
+
 AVStream filter-centric simulated capture sample driver (Avssamp)
 =================================================================
 

--- a/avstream/samplemft0/README.md
+++ b/avstream/samplemft0/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Driver MFT Sample
+    platform: WDM
+    language: cpp
+    category: Camera
+    description: A driver MFT for use with a camera's Windows Store device app.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617126
+--->
+
 Driver MFT Sample
 =================
 

--- a/biometrics/README.md
+++ b/biometrics/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Biometric Driver Samples (UMDF Version 1)
+    platform: UMDF1
+    language: cpp
+    category: Security Biometrics
+    description: Contains the Windows Biometric Driver Interface sample and the Windows Biometric Service Adapter samples.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620189
+--->
+
+
 Windows Biometric Driver Samples (UMDF Version 1)
 =================================================
 

--- a/bluetooth/bthecho/README.md
+++ b/bluetooth/bthecho/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Bluetooth Echo L2CAP Profile Driver
+    platform: WDM
+    language: cpp
+    category: Bluetooth
+    description: Demonstrates development of Bluetooth L2CAP profile drivers using the Bluetooth L2CAP DDIs. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617640
+--->
+
 Bluetooth Echo L2CAP Profile Driver
 ===================================
 

--- a/bluetooth/serialhcibus/README.md
+++ b/bluetooth/serialhcibus/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Bluetooth Serial HCI Bus Driver
+    platform: WDM
+    language: cpp
+    category: Bluetooth
+    description: Demonstrates how to implement a basic bus driver to support the new Bluetooth Extensibility transport DDIs over the UART transport.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617641
+--->
+
 Bluetooth Serial HCI Bus Driver
 ===============================
 

--- a/filesys/cdfs/README.md
+++ b/filesys/cdfs/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: CDFS File System Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: The CD-ROM file system driver (cdfs) sample is a file system driver for removable media.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617642
+--->
+
+
 CDFS File System Driver
 =======================
 

--- a/filesys/fastfat/README.md
+++ b/filesys/fastfat/README.md
@@ -1,3 +1,14 @@
+<!---
+    name: fastfat File System Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: A file system driver based on the Windows inbox FastFAT file system used as a model for new file systems.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620305
+--->
+
+
+
 fastfat File System Driver
 ==========================
 

--- a/filesys/miniFilter/MetadataManager/README.md
+++ b/filesys/miniFilter/MetadataManager/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Metadata Manager File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: An example of how to use files for storing metadata that corresponds to minifilters.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617650
+--->
+
+
 Metadata Manager File System Minifilter Driver
 ==============================================
 

--- a/filesys/miniFilter/NameChanger/README.md
+++ b/filesys/miniFilter/NameChanger/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: NameChanger File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: Grafts a directory from one part of a volume's namespace to another part using a mapping.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617652
+--->
+
+
 NameChanger File System Minifilter Driver
 =========================================
 

--- a/filesys/miniFilter/avscan/README.md
+++ b/filesys/miniFilter/avscan/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: AvScan File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: This filter is a transaction-aware file scanner that examines data in files.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617644
+--->
+
+
 AvScan File System Minifilter Driver
 ====================================
 

--- a/filesys/miniFilter/cancelSafe/README.md
+++ b/filesys/miniFilter/cancelSafe/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: CancelSafe File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: A minifilter demonstrating the use of cancel-safe queues.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617645
+--->
+
+
 CancelSafe File System Minifilter Driver
 ========================================
 

--- a/filesys/miniFilter/cdo/README.md
+++ b/filesys/miniFilter/cdo/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: CDO File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: An example of using a control device object (CDO) with a minifilter.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=
+--->
+
+
 CDO File System Minifilter Driver
 =================================
 

--- a/filesys/miniFilter/change/README.md
+++ b/filesys/miniFilter/change/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Change File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: A transaction-aware filter that monitors file changes in real time.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617647
+--->
+
+
 Change File System Minifilter Driver
 ====================================
 

--- a/filesys/miniFilter/ctx/README.md
+++ b/filesys/miniFilter/ctx/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Ctx File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: Demonstrates how to attach contexts to instances, files, streams, and stream handles in your minifilter. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617648
+--->
+
+
 Ctx File System Minifilter Driver
 =================================
 

--- a/filesys/miniFilter/delete/README.md
+++ b/filesys/miniFilter/delete/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Delete File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: Demonstrates how to detect deletions of files or streams.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617649
+--->
+
 Delete File System Minifilter Driver
 ====================================
 

--- a/filesys/miniFilter/minispy/README.md
+++ b/filesys/miniFilter/minispy/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Minispy File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: A tool to monitor and log any I/O and transaction activity that occurs in the system.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617651
+--->
+
+
 Minispy File System Minifilter Driver
 =====================================
 

--- a/filesys/miniFilter/nullFilter/README.md
+++ b/filesys/miniFilter/nullFilter/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: NullFilter File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: A minifilter that demonstrates registration with the filter manager.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617653
+--->
+
 NullFilter File System Minifilter Driver
 ========================================
 

--- a/filesys/miniFilter/passThrough/README.md
+++ b/filesys/miniFilter/passThrough/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: PassThrough File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: Demonstrates how to specify callback functions for different types of I/O requests.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617654
+--->
+
+
 PassThrough File System Minifilter Driver
 =========================================
 

--- a/filesys/miniFilter/scanner/README.md
+++ b/filesys/miniFilter/scanner/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Scanner File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: A file data scanner example. Typically, anti-virus filters are of this type.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617655
+--->
+
+
 Scanner File System Minifilter Driver
 =====================================
 

--- a/filesys/miniFilter/simrep/README.md
+++ b/filesys/miniFilter/simrep/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SimRep File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: Demonstrates how a file system filter can simulate file-system like reparse-point behavior to redirect a file open to an alternate path.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617656
+--->
+
+
 SimRep File System Minifilter Driver
 ====================================
 

--- a/filesys/miniFilter/swapBuffers/README.md
+++ b/filesys/miniFilter/swapBuffers/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SwapBuffer File System Minifilter Driver
+    platform: WDM
+    language: cpp
+    category: FileSystem
+    description: Demonstrates how to switch buffers between reads and writes of data. This technique is particularly useful for encryption filters.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617657
+--->
+
+
 SwapBuffer File System Minifilter Driver
 ========================================
 

--- a/general/DCHU/README.md
+++ b/general/DCHU/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: DHCU - Driver package installation toolkit for universal drivers 
+    platform: UMDF2
+    language: cpp
+    category: General DHCU
+    description: Illustrates DCHU principles of universal driver design.
+    samplefwlink: https://aka.ms/sceeqq
+--->
+
+
 # Driver package installation toolkit for universal drivers 
 
 This sample illustrates the DCHU principles of universal driver design.  The sample uses the [OSR FX2 learning kit](http://store.osr.com/product/osr-usb-fx2-learning-kit-v2/).  For a detailed code walkthrough, see [Universal Driver Scenarios](https://docs.microsoft.com/windows-hardware/drivers/develop/universal-driver-scenarios).

--- a/general/PLX9x5x/README.md
+++ b/general/PLX9x5x/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: PLX9x5x PCI Driver
+    platform: KMDF
+    language: cpp
+    category: General PCI WDF
+    description: Demonstrates how to write a driver for a generic PCI device using Windows Driver Frameworks (WDF).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617719
+--->
+
+
 PLX9x5x PCI Driver
 ==================
 

--- a/general/SystemDma/wdm/README.md
+++ b/general/SystemDma/wdm/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: System DMA sample
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates how a driver could use a system DMA controller to write data to a hardware location using V3 System DMA.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617722
+--->
+
+
 System DMA
 ==========
 

--- a/general/cancel/README.md
+++ b/general/cancel/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Cancel-Safe IRP Queue Sample
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates the use of the cancel-safe queue routines.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617705
+--->
+
+
 Cancel-Safe IRP Queue Sample
 ============================
 

--- a/general/echo/kmdf/README.md
+++ b/general/echo/kmdf/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: KMDF Echo Sample
+    platform: KMDF
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to use a sequential queue to serialize read and write requests presented to the driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617706
+--->
+
+
 KMDF Echo Sample
 ================
 

--- a/general/echo/umdf/README.md
+++ b/general/echo/umdf/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Echo Sample (UMDF Version 1)
+    platform: UMDF1
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to use UMDF version 1 to write a driver and demonstrates best practices.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617707
+--->
+
+
 Echo Sample (UMDF Version 1)
 ============================
 

--- a/general/echo/umdf2/README.md
+++ b/general/echo/umdf2/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Echo Sample (UMDF Version 2)
+    platform: UMDF2
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to use UMDF 2 to write a driver and to employ best practices.  
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617708
+--->
+
 Echo Sample (UMDF Version 2)
 ============================
 

--- a/general/echo/umdfSocketEcho/README.md
+++ b/general/echo/umdfSocketEcho/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: UMDF SocketEcho Sample (UMDF Version 1)
+    platform: UMDF1
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to use UMDF version 1 to write a driver and demonstrates best practices. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617709
+--->
+
+
 UMDF SocketEcho Sample (UMDF Version 1)
 =======================================
 

--- a/general/event/README.md
+++ b/general/event/README.md
@@ -1,3 +1,13 @@
+<!--- 
+    name: Hardware Event Sample
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates different ways a kernel-mode driver can notify an application about a hardware event.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617711
+--->
+
+
 Hardware Event Sample
 =====================
 

--- a/general/filehistory/README.md
+++ b/general/filehistory/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: File History Sample
+    platform: WDM
+    language: cpp
+    category: General
+    description: A console application that starts the file history service, if it is stopped, and schedules regular backups.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617712
+--->
+
+
 File History Sample
 ==================
 

--- a/general/installwdf/README.md
+++ b/general/installwdf/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WDF Installation Package
+    platform: Tool
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to install WDF packages on a system.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617713
+--->
+
+
 WDF Installation Package
 ========================
 

--- a/general/ioctl/kmdf/README.md
+++ b/general/ioctl/kmdf/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Non-PnP Driver Sample
+    platform: KMDF
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to write a non-PnP driver using the Kernel Mode Driver Framework. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620307
+--->
+
+
 Non-PnP Driver Sample
 ====================
 

--- a/general/ioctl/wdm/README.md
+++ b/general/ioctl/wdm/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: IOCTL
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates usage of four different types of IOCTLs
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617715
+--->
+
+
 IOCTL
 =====
 

--- a/general/obcallback/README.md
+++ b/general/obcallback/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: ObCallback Callback Registration Driver
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates the use of registered callbacks for process protection.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617716
+--->
+
+
 ObCallback Callback Registration Driver
 =======================================
 

--- a/general/pcidrv/README.md
+++ b/general/pcidrv/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: PCIDRV - WDF Driver for PCI Device
+    platform: KMDF
+    language: cpp
+    category: General PCI WDF
+    description: Demonstrates how to write a KMDF driver for a PCI device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617717
+--->
+
+
 PCIDRV - WDF Driver for PCI Device
 ==================================
 

--- a/general/perfcounters/kcs/README.md
+++ b/general/perfcounters/kcs/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Kernel Counter Sample (Kcs)
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates the use of the kernel-mode performance library.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617718
+--->
+
+
 Kernel Counter Sample (Kcs)
 ===========================
 

--- a/general/registry/regfltr/README.md
+++ b/general/registry/regfltr/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: RegFltr Sample Driver
+    platform: WDM
+    language: cpp
+    category: General
+    description: Demonstrates how to write a registry filter driver. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617720
+--->
+
+
 RegFltr Sample Driver
 =====================
 

--- a/general/toaster/toastDrv/README.md
+++ b/general/toaster/toastDrv/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Toaster Sample Driver
+    platform: KMDF UDMF1
+    language: cpp
+    category: General WDF
+    description: An iterative series of samples that demonstrate KDMF and UDMF1 driver development.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620309
+--->
+
+
 Toaster Sample Driver
 =====================
 The Toaster collection is an iterative series of samples that demonstrate fundamental aspects of Windows driver development for both Kernel-Mode Driver Framework (KMDF) and User-Mode Driver Framework (UMDF) version 1.

--- a/general/toaster/toastpkg/README.md
+++ b/general/toaster/toastpkg/README.md
@@ -1,5 +1,15 @@
-Toaster Sample Driver
-=====================
+<!---
+    name: Toaster Package Sample Driver
+    platform: WDM
+    language: cpp
+    category: General
+    description: Simulates hardware-first and software-first installation of the toaster sample driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617723
+--->
+
+
+Toaster Package Sample Driver
+=============================
 The Toaster collection is an iterative series of samples that demonstrate fundamental aspects of Windows driver development for both Kernel-Mode Driver Framework (KMDF) and User-Mode Driver Framework (UMDF) version 1.
 
 All the samples work with a hypothetical toaster bus, over which toaster devices can be connected to a PC.

--- a/general/toaster/umdf2/README.md
+++ b/general/toaster/umdf2/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Toaster Sample (UMDF version 2)
+    platform: UMDF2
+    language: cpp
+    category: General WDF
+    description: An iterative series of samples that demonstrate driver development using UMDF version 2.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620310
+--->
+
+
 Toaster Sample (UMDF Version 2)
 ===============================
 The Toaster (UMDF version 2) sample is an iterative series of samples that demonstrate fundamental aspects of Windows driver development.

--- a/general/tracing/SystemTraceControl/README.md
+++ b/general/tracing/SystemTraceControl/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: System Trace Control
+    platform: Application
+    language: cpp
+    category: General Tracing
+    description: Demonstrates how to use event tracing control APIs to collect events from the system trace provider.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617725
+--->
+
+
 SystemTraceProvider
 ===================
 

--- a/general/tracing/evntdrv/README.md
+++ b/general/tracing/evntdrv/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Eventdrv
+    platform: Application
+    language: cpp
+    category: General Tracing
+    description: Demonstrates the use of the Event Tracing for Windows (ETW) API in a driver. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617724
+--->
+
+
 Eventdrv
 ========
 

--- a/general/tracing/tracedriver/README.md
+++ b/general/tracing/tracedriver/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Tracedrv
+    platform: Application
+    language: cpp
+    category: General Tracing
+    description: A sample driver instrumented for software tracing.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617726
+--->
+
+
 Tracedrv
 ========
 

--- a/general/umdfSkeleton/README.md
+++ b/general/umdfSkeleton/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: UMDF Driver Skeleton Sample (UMDF version 1)
+    platform: UDMF1
+    language: cpp
+    category: General WDF
+    description: Demonstrates how to use UDMF to write a minimal driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617727
+--->
+
+
 UMDF Driver Skeleton Sample (UMDF Version 1)
 ============================================
 

--- a/gpio/samples/README.md
+++ b/gpio/samples/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: GPIO Sample Drivers
+    platform: KMDF UMDF1
+    language: cpp
+    category: GPIO
+    description: Illustrates how to write a GPIO controller driver that works in conjunction with the GPIO framework extension (GpioClx).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617729
+--->
+
+
 GPIO Sample Drivers
 ===================
 

--- a/hid/firefly/README.md
+++ b/hid/firefly/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: KMDF filter driver for a HID device
+    platform: KMDF
+    language: cpp
+    category: HID
+    description: Illustrates using remote I/O target interfaces to open a HID collection in kernel-mode and send IOCTL requests to set and get feature reports.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620192
+--->
+
+
 KMDF filter driver for a HID device
 ===================================
 Firefly is a KMDF-based filter driver for a HID device. Along with illustrating how to write a filter driver, this sample shows how to use remote I/O target interfaces to open a HID collection in kernel-mode and send IOCTL requests to set and get feature reports, as well as how an application can use WMI interfaces to send commands to a filter driver.

--- a/hid/hclient/README.md
+++ b/hid/hclient/README.md
@@ -1,3 +1,13 @@
+<!---
+    name:  HClient sample application
+    platform: WDM
+    language: cpp
+    category: HID
+    description: Demonstrates how to write a user-mode client application that communicates with HID devices.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617730
+--->
+
+
 HClient sample application
 ==========================
 

--- a/hid/hidusbfx2/README.md
+++ b/hid/hidusbfx2/README.md
@@ -1,3 +1,14 @@
+<!---
+    name: HIDUSBFX2 sample driver
+    platform: KMDF
+    language: cpp
+    category: HID
+    description: Demonstrates mapping of a non-HID USB device to a HID device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620190
+--->
+
+
+
 HIDUSBFX2 sample driver
 =======================
 The HIDUSBFX2 sample driver (hidusbfx2.sys) demonstrates how to map a non-HID USB device to a HID device.

--- a/hid/vhidmini2/README.md
+++ b/hid/vhidmini2/README.md
@@ -1,4 +1,13 @@
-HID Minidriver Sample (UMDF V2)
+<!---
+    name: HID Minidriver Sample (UMDF version 2)
+    platform: UMDF2
+    language: cpp
+    category: HID
+    description: Demonstrates how to write a HID minidriver using User-Mode Driver Framework (UMDF).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617731
+--->
+
+HID Minidriver Sample (UMDF version 2)
 ======================================
 The *HID minidriver* sample demonstrates how to write a HID minidriver using User-Mode Driver Framework (UMDF).
 

--- a/input/hiddigi/SynapticsTouch/README.md
+++ b/input/hiddigi/SynapticsTouch/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Synaptics Touch Sample
+    platform: KMDF
+    language: cpp
+    category: HID Touch
+    description: Demonstrates how to write a HID miniport driver for the Synaptics 3202 touch controller.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620196
+--->
+
+
 Synaptics Touch Sample
 ======================
 
@@ -15,15 +25,6 @@ Related technologies
 [Human Interface Devices](http://msdn.microsoft.com/en-us/library/windows/hardware/jj126202)
 
 [Windows Pointer Device](http://msdn.microsoft.com/en-us/library/windows/hardware/jj151570)
-
-
-##System requirements
--------------------
-**Client:** Windows 10 Technical Preview
-
-**Server:** Windows 10 Technical Preview
-
-**Phone:**  Windows 10 Technical Preview
 
 
 File Manifest

--- a/input/kbfiltr/README.md
+++ b/input/kbfiltr/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Keyboard Input WDF Filter Driver (Kbfiltr)
+    platform: KMDF
+    language: cpp
+    category: HID WDF
+    description: A WDF example of a keyboard input filter driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620194
+--->
+
+
 Keyboard Input WDF Filter Driver (Kbfiltr)
 ==========================================
 

--- a/input/layout/README.md
+++ b/input/layout/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Keyboard Layout Samples
+    platform: Application
+    language: cpp
+    category: HID
+    description: Demonstrates how to generate layouts for various keyboards and locales.
+    samplefwlink: https://aka.ms/rapjms
+--->
+
+
 Keyboard Layout Samples
 =======================
 

--- a/input/moufiltr/README.md
+++ b/input/moufiltr/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Mouse Input WDF Filter Driver (Moufiltr)
+    platform: KMDF
+    language: cpp
+    category: HID WDF
+    description: A WDF example of a mouse input filter driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620195
+--->
+
+
 Mouse Input WDF Filter Driver (Moufiltr)
 ========================================
 The Moufiltr sample is an example of a mouse input filter driver.

--- a/network/config/bindview/README.md
+++ b/network/config/bindview/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Bindview Network Configuration Utility
+    platform: Application
+    language: cpp
+    category: Network
+    description: An application that demonstrates how to use INetCfg APIs to enumerate, install, uninstall, bind and unbind network components.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617732
+--->
+
+
 Bindview Network Configuration Utility
 ======================================
 

--- a/network/modem/fakemodem/README.md
+++ b/network/modem/fakemodem/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Fakemodem Driver
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: Demonstrates a simple controller-less modem driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617733
+--->
+
 Fakemodem Driver
 ================
 

--- a/network/ndis/extension/README.md
+++ b/network/ndis/extension/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Hyper-V Extensible Switch extension filter driver
+    platform: WDM
+    language: cpp
+    category: Network
+    description: A base library used to implement a Hyper-V Extensible Switch extension filter driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617913
+--->
+
+
 Hyper-V Extensible Switch extension filter driver
 =================================================
 

--- a/network/ndis/filter/README.md
+++ b/network/ndis/filter/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: NDIS 6.0 Filter Driver
+    platform: WDM
+    language: cpp
+    category: Network
+    description: A pass-through NDIS 6 filter driver demonstrating the basic principles of an NDIS 6.0 Filter driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617915
+--->
+
+
 NDIS 6.0 Filter Driver
 ======================
 

--- a/network/ndis/mux/README.md
+++ b/network/ndis/mux/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: NDIS MUX Intermediate Driver and Notify Object
+    platform: WDM
+    language: cpp
+    category: Network
+    description: An NDIS 6.0 driver that demonstrates the operation of an N:1 MUX driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617916
+--->
+
+
 NDIS MUX Intermediate Driver and Notify Object
 ==============================================
 

--- a/network/ndis/ndisprot/6x/README.md
+++ b/network/ndis/ndisprot/6x/README.md
@@ -1,7 +1,17 @@
-NDIS Connection-less Protocol Driver Sample
-===========================================
+<!---
+    name: NDIS Connection-less Protocol WDM Driver Sample
+    platform: WDM
+    language: cpp
+    category: Network
+    description:  Demonstrates a connection-less NDIS 6.0 protocol WDM driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617917
+--->
 
-This sample demonstrates a connection-less NDIS 6.0 protocol.The driver supports sending and receiving raw Ethernet frames using `ReadFile`/`WriteFile` calls from user-mode. It only receives frames with a specific EtherType field. As an NDIS protocol, it illustrates how to establish and tear down bindings to Ethernet adapters, i.e. those that export medium type **NdisMedium802\_3**. It shows how to set a packet filter, send and receive data, and handle plug-and-play events.
+
+NDIS Connection-less Protocol WDM Driver Sample
+===============================================
+
+This sample demonstrates a connection-less NDIS 6.0 protocol WDM driver. The driver supports sending and receiving raw Ethernet frames using `ReadFile`/`WriteFile` calls from user-mode. It only receives frames with a specific EtherType field. As an NDIS protocol, it illustrates how to establish and tear down bindings to Ethernet adapters, i.e. those that export medium type **NdisMedium802\_3**. It shows how to set a packet filter, send and receive data, and handle plug-and-play events.
 
 ### INSTALLATION
 

--- a/network/ndis/ndisprot_kmdf/README.md
+++ b/network/ndis/ndisprot_kmdf/README.md
@@ -1,6 +1,17 @@
-Connection-less NDIS 6.0 Sample Protocol Driver
-===============================================
-This sample demonstrates a connection-less NDIS 6.0 protocol driver.
+<!---
+    name: Connection-less NDIS 6.0 Protocol KMDF Sample Driver
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: Demonstrates a connection-less NDIS 6.0 protocol KMDF driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620197
+--->
+
+
+Connection-less NDIS 6.0 Protocol KMDF Sample Driver
+====================================================
+
+This sample demonstrates a connection-less NDIS 6.0 protocol KMDF driver.
 
 The driver supports sending and receiving raw Ethernet frames using ReadFile/WriteFile calls from user-mode. As an NDIS protocol, it illustrates how to establish and tear down bindings to Ethernet adapters, i.e. those that export medium type *NdisMedium802\_3*. It shows how to set a packet filter, send and receive data, and handle plug-and-play events.
 

--- a/network/ndis/netvmini/6x/README.md
+++ b/network/ndis/netvmini/6x/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: NDIS Virtual Miniport Driver
+    platform: WDM
+    language: cpp
+    category: Network
+    description: Demonstrates the functionality of an NDIS miniport driver without requiring a physical network adapter.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617918
+--->
+
+
 NDIS Virtual Miniport Driver
 ============================
 

--- a/network/radio/HidSwitchDriverSample/README.md
+++ b/network/radio/HidSwitchDriverSample/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Radio Switch Test Driver for OSR USB-FX2 Development Board
+    platform: KMDF
+    language: cpp
+    category: Network Radio
+    description: Demonstrates how to structure a HID driver for radio switches for the OSR USB-FX2 Development Board.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617919
+--->
+
+
 Radio Switch Test Driver for OSR USB-FX2 Development Board
 ==========================================================
 

--- a/network/radio/RadioManagerSample/README.md
+++ b/network/radio/RadioManagerSample/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Radio Management Sample
+    platform: WDM
+    language: cpp
+    category: Network Radio
+    description: Demonstrates how to structure a Radio Manager for use with the Windows Radio Management APIs.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617920
+--->
+
+
 Windows Radio Management Sample
 ===============================
 

--- a/network/trans/WFPSampler/README.md
+++ b/network/trans/WFPSampler/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Filtering Platform Sample
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: A sample firewall that has a command-line interface which allows adding filters at various WFP layers.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620198
+--->
+
+
 Windows Filtering Platform Sample
 =================================
 

--- a/network/trans/ddproxy/README.md
+++ b/network/trans/ddproxy/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Filtering Platform Packet Modification Sample
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: Demonstrates the packet modification capabilities of the Windows Filtering Platform (WFP).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617930
+--->
+
+
 Windows Filtering Platform Packet Modification Sample
 =====================================================
 

--- a/network/trans/inspect/README.md
+++ b/network/trans/inspect/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Filtering Platform Traffic Inspection Sample
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: Demonstrates the traffic inspection capabilities of the Windows Filtering Platform (WFP).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617931
+--->
+
+
 Windows Filtering Platform Traffic Inspection Sample
 ====================================================
 

--- a/network/trans/msnmntr/README.md
+++ b/network/trans/msnmntr/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Filtering Platform MSN Messenger Monitor Sample
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: Demonstrates the stream inspection capabilities of the Windows Filtering Platform (WFP). 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617932
+--->
+
+
 Windows Filtering Platform MSN Messenger Monitor Sample
 =======================================================
 

--- a/network/trans/stmedit/README.md
+++ b/network/trans/stmedit/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Windows Filtering Platform Stream Edit Sample
+    platform: KMDF
+    language: cpp
+    category: Network
+    description: Demonstrates replacing a string pattern for a Transmission Control Protocol (TCP) connection using the Windows Filtering Platform (WFP).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617933
+--->
+
+
 Windows Filtering Platform Stream Edit Sample
 =============================================
 

--- a/network/wsk/echosrv/README.md
+++ b/network/wsk/echosrv/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WSK TCP Echo Server
+    platform: WDM
+    language: cpp
+    category: Network
+    description: A minimal sample driver to demonstrate the usage of the Winsock Kernel (WSK) programming interface.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617935
+--->
+
+
 WSK TCP Echo Server
 ===================
 

--- a/nfc/Simulator/README.md
+++ b/nfc/Simulator/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: NFC Simulator Driver Sample
+    platform: UMDF2
+    language: cpp
+    category: NFC
+    description: Demonstrates how to use UMDF to write a Near-Field Communication (NFC) universal driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620199
+--->
+
+
 NFC Simulator Driver Sample
 ===========================
 This sample demonstrates how to use User-Mode Driver Framework (UMDF) to write a Near-Field Communication (NFC) universal driver along with best practices.

--- a/nfp/net/README.md
+++ b/nfp/net/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Near-Field Proximity Sample Driver (UMDF Version 1)
+    platform: UMDF1
+    language: cpp
+    category: Proximity
+    description: Demonstrates how to use UMDF version 1 to write a near-field proximity driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620200
+--->
+
+
 Near-Field Proximity Sample Driver (UMDF Version 1)
 ===================================================
 

--- a/pofx/PEP/README.md
+++ b/pofx/PEP/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Power Engine Plugin (PEP) ACPI Sample
+    platform: KMDF
+    language: cpp
+    category: ACPI Power
+    description: Demonstrates an interface which allows PEP to implement ACPI runtime methods natively via a driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620311
+--->
+
+
 PEP ACPI Sample
 ===============
 

--- a/pofx/UMDF2/README.md
+++ b/pofx/UMDF2/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Power Framework (PoFx) Sample (UMDF Version 2)
+    platform: UMDF2
+    language: cpp
+    category: Power
+    description: Demonstrates how a UMDF version 2 driver can implement F-state-based power management.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617936
+--->
+
+
 Power Framework (PoFx) Sample (UMDF Version 2)
 ==============================================
 

--- a/pofx/WDF/README.md
+++ b/pofx/WDF/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: KMDF Power Framework (PoFx) Sample
+    platform: KMDF
+    language: cpp
+    category: Power
+    description: Demonstrate how a KMDF driver can implement F-state-based power management.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617937
+--->
+
+
 KMDF Power Framework (PoFx) Sample
 ==================================
 

--- a/pos/drivers/MagneticStripeReader/README.md
+++ b/pos/drivers/MagneticStripeReader/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Magnetic Stripe Reader Driver Sample
+    platform: UMDF2
+    language: cpp
+    category: POS
+    description: This UMDF version 2 sample serves as a template for creating a new Magnetic Stripe Reader driver. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620202
+--->
+
+
 Magnetic Stripe Reader Driver Sample
 ====================================
 This sample serves as a template for creating a new Magnetic Stripe Reader driver.  

--- a/pos/drivers/barcodescanner/README.md
+++ b/pos/drivers/barcodescanner/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Barcode Scanner Driver Sample
+    platform: UMDF2
+    language: cpp
+    category: POS
+    description: This UDMF version 2 sample serves as a template for creating a new Barcode Scanner driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620201
+--->
+
+
 Barcode Scanner Driver Sample
 ====================================
 This sample serves as a template for creating a new Barcode Scanner driver.  

--- a/print/SampleOpenXPS/README.md
+++ b/print/SampleOpenXPS/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: OpenXPS Documents Print Sample
+    platform: Application
+    language: cpp
+    category: Print
+    description: Contains a set of documents that exercise a variety of features of OpenXPS.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617941
+--->
+
+
 OpenXPS Documents Print Sample
 ==============================
 

--- a/print/SampleXPS/README.md
+++ b/print/SampleXPS/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: XPS Documents Print Sample
+    platform: Application
+    language: cpp
+    category: Print
+    description: Contains a set of documents that exercise a variety of features of the XML Paper Specification.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617942
+--->
+
+
 XPS Documents Print Sample
 ==========================
 

--- a/print/SimplePipelineFilter/README.md
+++ b/print/SimplePipelineFilter/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Print Pipeline Simple Filter
+    platform: DLL
+    language: cpp
+    category: Print
+    description: This sample shows how to use the print pipeline's filter interfaces.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617944
+--->
+
+
 Print Pipeline Simple Filter
 ============================
 

--- a/print/XPSDrvSmpl/README.md
+++ b/print/XPSDrvSmpl/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: XPSDrv Driver and Filter Sample
+    platform: DLL
+    language: cpp
+    category: Print
+    description: Provide a starting point for developing XPSDrv printer drivers and to illustrate the facility and potential of an XPSDrv print driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617950
+--->
+
+
 XPSDrv Driver and Filter Sample
 ===============================
 

--- a/print/XpsRasFilter/README.md
+++ b/print/XpsRasFilter/README.md
@@ -1,3 +1,14 @@
+<!---
+    name: XPS Rasterization Filter Service Sample
+    platform: DLL
+    language: cpp
+    category: Print
+    description: Implements an XPSDrv filter that rasterizes fixed pages in an XPS document.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617951
+--->
+
+
+
 XPS Rasterization Filter Service Sample
 =======================================
 

--- a/print/autoconfig/README.md
+++ b/print/autoconfig/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Print auto-configuration sample
+    platform: Utility
+    language: cpp
+    category: Print
+    description: Demonstrates how to implement auto-configuration in v4 print drivers.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617938
+--->
+
+
 Print auto-configuration sample
 ===============================
 

--- a/print/cpsuisam/README.md
+++ b/print/cpsuisam/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Common Property Sheet User Interface (CPSUI) Sample
+    platform: Application
+    language: cpp
+    category: Print
+    description: The CPSUISAM application causes the CPSUI to call the print spooler to create property sheet pages for the default printer.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617940
+--->
+
+
 Common Property Sheet UI Sample
 ===============================
 

--- a/print/v4PrintDriverSamples/PrinterExtensionSample/README.md
+++ b/print/v4PrintDriverSamples/PrinterExtensionSample/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Printer Extension Sample
+    platform: Application
+    language: cs
+    category: Print
+    description: Demonstrates how to use .NET to build a customized, desktop UI for a v4 print driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617945
+--->
+
+
 Printer Extension Sample
 ========================
 

--- a/print/v4PrintDriverSamples/v4PrintDriver-ConstraintScript/README.md
+++ b/print/v4PrintDriverSamples/v4PrintDriver-ConstraintScript/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Print Driver Constraints Sample
+    platform: Utility
+    language: js
+    category: Print
+    description: Demonstrates how to implement advanced constraint handling and PrintTicket/PrintCapabilities handling using JavaScript.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617946
+--->
+
+
 Print Driver Constraints Sample
 ===============================
 

--- a/print/v4PrintDriverSamples/v4PrintDriver-HostBasedSampleDriver/README.md
+++ b/print/v4PrintDriverSamples/v4PrintDriver-HostBasedSampleDriver/README.md
@@ -1,3 +1,14 @@
+<!---
+    name: USB Host-Based Print Driver Sample
+    platform: Utility
+    language: js
+    category: Print
+    description: Demonstrates how to support host-based devices that use the v4 print driver model and are connected via USB.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617947
+--->
+
+
+
 USB Host-Based Print Driver Sample
 ==================================
 

--- a/print/v4PrintDriverSamples/v4PrintDriver-USBMon-Bidi-Extension/README.md
+++ b/print/v4PrintDriverSamples/v4PrintDriver-USBMon-Bidi-Extension/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Print Driver USB Monitor and Bidi Sample
+    platform: Utility
+    language: js xml
+    category: Print
+    description: Demonstrates how to support bidirectional (Bidi) communication over the USB bus using JavaScript and XML.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617948
+--->
+
+
 Print Driver USB Monitor and Bidi Sample
 ========================================
 

--- a/print/v4PrintDriverSamples/v4PrintDriver-WSDMon-Bidi-Extension/README.md
+++ b/print/v4PrintDriverSamples/v4PrintDriver-WSDMon-Bidi-Extension/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WSDMon Bidi Extension Sample
+    platform: Utility
+    language: xml
+    category: Print
+    description: Demonstrates how to use an XML extension file to support bidirectional (Bidi) communication with a WSD connected printer.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617949
+--->
+
+
 WSDMon Bidi Extension Sample
 ============================
 

--- a/sd/miniport/sdhc/README.md
+++ b/sd/miniport/sdhc/README.md
@@ -1,5 +1,15 @@
+<!---
+    name: Standard SD Host Controller Miniport
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: Provides a functional miniport implementation for a standard SD host controller.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617952
+--->
+
+
 Standard SD Host Controller Miniport
-===================
+====================================
 
 This is a sample for a Secure Digital (SD) Host Controller miniport driver. The driver works in conjunction with sdport.sys, which implements SD/SDIO/eMMC protocol and WDM interfaces, to provide the host register interface.
 

--- a/sd/sdiomars/README.md
+++ b/sd/sdiomars/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SDIO Driver 
+    platform: KMDF
+    language: cpp
+    category: Storage
+    description: A functional KMDF Secure Digital (SD) IO driver for use with a generic mars development board.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617953
+--->
+
+
 Storage SDIO Driver
 ===================
 

--- a/security/elam/README.md
+++ b/security/elam/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Early Launch Anti-Malware Driver
+    platform: KMDF
+    language: cpp
+    category: Security
+    description: Demonstrates how to receive notifications about the initialization of regular boot start drivers in an Early Launch Anti-Malware driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617954
+--->
+
+
 Early Launch Anti-Malware Driver
 ================================
 

--- a/serial/VirtualSerial/README.md
+++ b/serial/VirtualSerial/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Virtual serial driver sample
+    platform: UDMF1
+    language: cpp
+    category: Serial
+    description: Demonstrates a simple virtual serial driver (ComPort) and a controller-less modem driver (FakeModem).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617963
+--->
+
+
 Virtual serial driver sample
 ============================
 

--- a/serial/VirtualSerial2/README.md
+++ b/serial/VirtualSerial2/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Virtual serial driver sample (UMDF version 2)
+    platform: UMDF2
+    language: cpp
+    category: Serial
+    description: Demonstrates UMDF version 2 serial drivers and includes a simple virtual serial driver (ComPort) and a controller-less modem driver (FakeModem).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617965
+--->
+
+
 Virtual serial driver sample
 ============================
 

--- a/serial/serenum/README.md
+++ b/serial/serenum/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Serenum sample
+    platform: WDM
+    language: cpp
+    category: Serial
+    description: Enumerates Plug-n-Play RS-232 devices that are compliant with the current revision of Plug and Play External COM Device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617961
+--->
+
+
 Serenum sample
 ==============
 

--- a/serial/serial/README.md
+++ b/serial/serial/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Serial Port Driver
+    platform: KMDF
+    language: cpp
+    category: Serial
+    description: The Serial (16550-based RS-232) sample driver is a WDF version of the inbox Serial.sys driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617962
+--->
+
+
 Serial Port Driver
 ==================
 

--- a/setup/devcon/README.md
+++ b/setup/devcon/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Device Console (DevCon) Tool
+    platform: Tool
+    language: cpp
+    category: Setup
+    description: DevCon enables, disables, installs, configures, and removes devices on the local computer and displays detailed information about devices on local and remote computers.
+    samplefwlink: https://go.microsoft.com/fwlink/p/?linkid=856741
+--->
+
+
 Device Console (DevCon) Tool
 ============================
 

--- a/simbatt/README.md
+++ b/simbatt/README.md
@@ -1,3 +1,13 @@
-SimBatt: Battery Battery Driver Sample
+<!---
+    name: Simulated Battery Driver Sample
+    platform: KMDF
+    language: cpp
+    category: Battery Power
+    description: Demonstrates a KMDF-based implementation of Windows battery driver interfaces.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620188
+--->
+
+
+SimBatt: Simulated Battery Driver Sample
 ======================================
 SimBatt is simulated battery device driver, this source code is intended to demonstrate implementation of Windows battery driver interfaces. This is a KMDF based sample. You may use this sample as a starting point to implement a battery miniport specific to your needs.

--- a/smartcrd/README.md
+++ b/smartcrd/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: PCMCIA Smart Card Driver
+    platform: KMDF
+    language: cpp
+    category: SmartCard
+    description: Demonstrates how to write a KMDF driver for the SCM Microsystems PCMCIA smart card reader.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617968
+--->
+
+
 PCMCIA Smart Card Driver
 ========================
 

--- a/spb/SkeletonI2C/README.md
+++ b/spb/SkeletonI2C/README.md
@@ -1,5 +1,15 @@
+<!---
+    name: Skeleton I2C Sample Driver
+    platform: KMDF
+    language: cpp
+    category: SimplePeripheralBus
+    description: Demonstrates how to design a KMDF controller driver for Windows that conforms to the simple peripheral bus (SPB) device driver interface (DDI).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617969
+--->
+
+
 Skeleton I2C Sample Driver
-=========================
+==========================
 
 The SkeletonI2C sample demonstrates how to design a KMDF controller driver for Windows that conforms to the [simple peripheral bus](http://msdn.microsoft.com/en-us/library/windows/hardware/hh450903) (SPB) device driver interface (DDI). SPB is an abstraction for low-speed serial buses (for example, I<sup>2</sup>C and SPI) that allows peripheral drivers to be developed for cross-platform use without any knowledge of the underlying bus hardware or device connections. While this sample implements an empty I<sup>2</sup>C driver, it could just as easily be the starting point for an SPI driver with only minor modifications.
 

--- a/spb/SpbTestTool/README.md
+++ b/spb/SpbTestTool/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SpbTestTool sample
+    platform: KMDF
+    language: cpp
+    category: SimplePeripheralBus
+    description: Demonstrates how to open a handle to the SPB controller, use the SPB interface from a KMDF driver, and employ GPIO.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617970
+--->
+
+
 SpbTestTool
 ===========
 

--- a/storage/class/cdrom/README.md
+++ b/storage/class/cdrom/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: CDROM Storage Class Driver
+    platform: KMDF
+    language: cpp
+    category: Storage
+    description: Provide access to CD, DVD and Blu-ray drives, supports Plug and Play, Power Management, and AutoRun (media change notification). 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617971
+--->
+
+
 CDROM Storage Class Driver
 ==========================
 

--- a/storage/class/classpnp/README.md
+++ b/storage/class/classpnp/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: ClassPnP Class Driver Library 
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: A library storage class driver used by disk, CDROM, and the tape class drivers.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617978
+--->
+
+
 ClassPnP Storage Class Driver Library
 =====================================
 

--- a/storage/class/disk/README.md
+++ b/storage/class/disk/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Disk Class Driver
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: A class driver for disk devices.  
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617979
+--->
+
+
 Disk Class Driver
 =================
 

--- a/storage/filters/addfilter/README.md
+++ b/storage/filters/addfilter/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: AddFilter Storage Filter Tool
+    platform: Application
+    language: cpp
+    category: Storage
+    description: A command-line application that adds and removes filter drivers for a given drive or volume.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617980
+--->
+
+
 AddFilter Storage Filter Tool
 =============================
 

--- a/storage/iscsi/README.md
+++ b/storage/iscsi/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: iSCSI WMI Client 
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: A WMI iSCSI miniport that can be tested using the iSCSICLI.exe tool, the iSCSI Initiator Properties page, the WBEMTEST.exe tool, and customized WMI scripts. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617981
+--->
+
+
 iSCSI WMI Client
 ================
 

--- a/storage/miniports/lsi_u3/README.md
+++ b/storage/miniports/lsi_u3/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: LSI_U3 StorPort Miniport Driver
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: An adapter driver for use with Parallel SCSI Host Bus Adapters or on-motherboard solutions that use the LSI 53C1010 SCSI ASIC.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617982
+--->
+
+
 LSI\_U3 StorPort Miniport Driver
 ================================
 

--- a/storage/miniports/storahci/README.md
+++ b/storage/miniports/storahci/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: StorAHCI StorPort Miniport   
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: A sample Storport ACHI miniport driver.  
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617983
+--->
+
+
 StorAhci StorPort Miniport Driver
 =================================
 

--- a/storage/msdsm/README.md
+++ b/storage/msdsm/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Multipath I/O (MPIO) DSM Sample 
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: Provides a sample for building vendor-specific device-specific modules (DSM), supports iSCSI and Fibre Channel devices.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620203
+--->
+
+
 Multipath I/O (MPIO) DSM Sample
 ===============================
 

--- a/storage/ramdisk/README.md
+++ b/storage/ramdisk/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: RAMDisk Storage Driver Sample
+    platform: KMDF
+    language: cpp
+    category: Storage
+    description: Demonstrates how to write a RAM disk software-only function driver using KMDF.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617988
+--->
+
+
 RAMDisk Storage Driver Sample
 =============================
 

--- a/storage/sfloppy/README.md
+++ b/storage/sfloppy/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Super Floppy (sfloppy) Storage Class Driver
+    platform: WDM
+    language: cpp
+    category: Storage
+    description: A smaple class driver for Super Floppy disk drives.     
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617989
+--->
+
+
 Super Floppy (sfloppy) Storage Class Driver
 ===========================================
 

--- a/storage/tools/spti/README.md
+++ b/storage/tools/spti/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SCSI Pass-Through Interface Tool
+    platform: Application
+    language: cpp
+    category: Storage
+    description:  Demonstrates how to communicate with a SCSI device using pass-through IOCTLs in an application using DeviceIoControl API.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617990
+--->
+
+
 SCSI Pass-Through Interface Tool
 ================================
 

--- a/thermal/simsensor/README.md
+++ b/thermal/simsensor/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SimSensor - Simulated Temperature Sensor Sample Driver
+    platform: KMDF
+    language: cpp
+    category: Thermal Power
+    description: Demonstrates a simulated temperature sensor device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617991
+--->
+
+
 SimSensor: Simulated Temperature Sensor Sample Driver
 =====================================================
 

--- a/thermal/thermalclient/README.md
+++ b/thermal/thermalclient/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SimThermalClient - Simulated Thermal Client Sample Driver
+    platform: KMDF
+    language: cpp
+    category: Thermal Power
+    description: Simulates a device that is a Windows thermal management client.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617992
+--->
+
+
 SimThermalClient: Simulated Thermal Client Sample Driver
 ========================================================
 

--- a/tools/sdv/samples/DV-FailDriver-WDM/README.md
+++ b/tools/sdv/samples/DV-FailDriver-WDM/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: DV-FailDriver-WDM
+    platform: WDM
+    language: cpp
+    category: DriverVerifier Tools
+    description: Demonstrates how Driver Verifier (DV) can find errors in a WDM driver.
+    samplefwlink: https://go.microsoft.com/fwlink/p/?linkid=856743
+--->
+
+
 DV-FailDriver-WDM
 =================
 

--- a/tools/sdv/samples/SDV-FailDriver-KMDF/README.md
+++ b/tools/sdv/samples/SDV-FailDriver-KMDF/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SDV-FailDriver-KMDF
+    platform: KMDF
+    language: cpp
+    category: StaticDriverVerifier Tools
+    description: Demonstrates how Static Driver Verifier (SDV) can find errors in a KMDF driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617993
+--->
+
+
 SDV-FailDriver-KMDF
 ===================
 

--- a/tools/sdv/samples/SDV-FailDriver-NDIS/README.md
+++ b/tools/sdv/samples/SDV-FailDriver-NDIS/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SDV-FailDriver-NDIS
+    platform: WDM
+    language: cpp
+    category: StaticDriverVerifier Network
+    description: Demonstrates how Static Driver Verifier (SDV) can find errors in a NDIS driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617995
+--->
+
+
 SDV-FailDriver-NDIS
 ===================
 

--- a/tools/sdv/samples/SDV-FailDriver-STORPORT/README.md
+++ b/tools/sdv/samples/SDV-FailDriver-STORPORT/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SDV-FailDriver-STORPORT
+    platform: KMDF
+    language: cpp
+    category: StaticDriverVerifier 
+    description: Demonstrates how Static Driver Verifier (SDV) can find errors in a Storport driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617997
+--->
+
+
 SDV-FailDriver-STORPORT
 =======================
 

--- a/tools/sdv/samples/SDV-FailDriver-WDM/README.md
+++ b/tools/sdv/samples/SDV-FailDriver-WDM/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: SDV-FailDriver-WDM
+    platform: WDM
+    language: cpp
+    category: StaticDriverVerifier
+    description: Demonstrates how Static Driver Verifier (SDV) can find errors in a WDM driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=617999
+--->
+
+
 SDV-FailDriver-WDM
 ==================
 

--- a/usb/UcmCxUcsi/README.md
+++ b/usb/UcmCxUcsi/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: UcmTcpciCx Port Controller Client Driver
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to create a Windows USB Type-C port controller driver using the USB Connector Manager class extension driver (UcmCx).
+    samplefwlink: https://go.microsoft.com/fwlink/p/?linkid=856744
+--->
+
+
 # UcmTcpciCx Port Controller Client Driver
 
 This is a sample driver that shows how to create a Windows USB Type-C port controller driver using the USB Connector Manager class extension driver (UcmCx). The sample is a driver for an embedded controller which is complient with the [USB Type-C Connector System Software Interface (UCSI)](http://www.intel.com/content/www/us/en/io/universal-serial-bus/usb-type-c-ucsi-spec.html).

--- a/usb/UcmTcpciCxClientSample/README.md
+++ b/usb/UcmTcpciCxClientSample/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: UcmTcpciCx Port Controller Client Driver
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to create a Windows USB Type-C port controller driver using the USB Connector Manager Type-C Port Controller Interface class extension driver (UcmTcpciCx).
+    samplefwlink: https://go.microsoft.com/fwlink/p/?linkid=856745
+--->
+
+
 # UcmTcpciCx Port Controller Client Driver
 
 This is a skeleton sample driver that shows how to create a Windows USB Type-C port controller driver using the USB Connector Manager Type-C Port Controller Interface class extension driver (UcmTcpciCx). UcmTcpciCx is currently only availble using the Windows Insider program - documentation for UcmTcpciCx will be available at the next release of Windows.

--- a/usb/kmdf_enumswitches/README.md
+++ b/usb/kmdf_enumswitches/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Sample KMDF Bus Driver for OSR USB-FX2
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to use KMDF as a bus driver using the OSR USB-FX2 device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618000
+--->
+
+
 Sample KMDF Bus Driver for OSR USB-FX2
 ======================================
 

--- a/usb/kmdf_fx2/README.md
+++ b/usb/kmdf_fx2/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Sample KMDF Function Driver for OSR USB-FX2
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to use KMDF to perform bulk and interrupt data transfers to a USB device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620313
+--->
+
+
 Sample KMDF Function Driver for OSR USB-FX2
 ===========================================
 

--- a/usb/ufxclientsample/README.md
+++ b/usb/ufxclientsample/README.md
@@ -1,4 +1,14 @@
-﻿USB Function Client Driver
+﻿<!---
+    name: USB Function Client Driver
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to create a Windows USB function controller driver using the USB function class extension driver (UFX).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620315
+--->
+
+
+USB Function Client Driver
 ==========================
 
 This is a skeleton sample driver that shows how to create a Windows USB function controller driver using the USB function class extension driver (UFX).

--- a/usb/umdf2_fx2/README.md
+++ b/usb/umdf2_fx2/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Sample Function Driver for OSR USB-FX2 (UMDF Version 2)
+    platform: UMDF2
+    language: cpp
+    category: USB
+    description: Demomstreates a UMDF version 2 driver for the OSR USB-FX2 device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618003
+--->
+
 Sample Function Driver for OSR USB-FX2 (UMDF Version 2)
 =======================================================
 
@@ -55,7 +64,7 @@ Build the sample using MSBuild
 
 As an alternative to building the driver sample in Visual Studio, you can build it in a Visual Studio Command Prompt window. In Visual Studio, on the **Tools** menu, choose **Visual Studio Command Prompt**. In the Visual Studio Command Prompt window, navigate to the folder that has the solution file, umdf2echo.sln. Use the MSBuild command to build the solution. Here is an example:
 
-**msbuild /p:configuration=”Win8 Release” /p:platform=”Win32” umdf2\_fx2.sln**
+**msbuild /p:configuration=ï¿½Win8 Releaseï¿½ /p:platform=ï¿½Win32ï¿½ umdf2\_fx2.sln**
 
 For more information about using MSBuild to build a driver package, see [Building a Driver](http://msdn.microsoft.com/en-us/library/windows/hardware/ff554644).
 

--- a/usb/umdf_filter_kmdf/README.md
+++ b/usb/umdf_filter_kmdf/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Sample UMDF Filter above KMDF Function Driver for OSR USB-FX2 (UMDF Version 1)
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to load a UMDF filter driver as an upper filter driver above the kmdf_fx2 sample driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620316
+--->
+
+
 Sample UMDF Filter above KMDF Function Driver for OSR USB-FX2 (UMDF Version 1)
 ==============================================================================
 

--- a/usb/umdf_filter_umdf/README.md
+++ b/usb/umdf_filter_umdf/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Sample UMDF Filter above UMDF Function Driver for OSR USB-FX2 (UMDF Version 1)
+    platform: UMDF1
+    language: cpp
+    category: USB
+    description: Demonstrates how to load a UMDF filter driver as an upper filter driver above the umdf_fx2 sample driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618001
+--->
+
+
 Sample UMDF Filter above UMDF Function Driver for OSR USB-FX2 (UMDF Version 1)
 ==============================================================================
 

--- a/usb/umdf_fx2/README.md
+++ b/usb/umdf_fx2/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Sample UMDF Function Driver for OSR USB-FX2 (UMDF version 1)
+    platform: UMDF1
+    language: cpp
+    category: USB
+    description: A UMDF driver for the OSR USB-FX2 device that includes a test application, sample device metadata, and supports impersonation and idle power down. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618002
+--->
+
+
 Sample UMDF Function Driver for OSR USB-FX2 (UMDF Version 1)
 ============================================================
 

--- a/usb/usbsamp/README.md
+++ b/usb/usbsamp/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: Usbsamp Generic USB Driver
+    platform: KMDF
+    language: cpp
+    category: USB
+    description: Demonstrates how to perform full speed, high speed, and SuperSpeed transfers to and from bulk and isochronous endpoints of a generic USB device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618938
+--->
+
+
 Usbsamp Generic USB Driver
 ==========================
 

--- a/usb/usbview/README.md
+++ b/usb/usbview/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: USBView sample application
+    platform: WDM
+    language: cpp
+    category: USB
+    description: Provides an application that allows you to browse all USB controllers and connected USB devices on your system.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618004
+--->
+
+
 USBView sample application
 ==========================
 

--- a/usb/wdf_osrfx2_lab/README.md
+++ b/usb/wdf_osrfx2_lab/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WDF Sample Driver Learning Lab for OSR USB-FX2
+    platform: UMDF KMDF
+    language: cpp
+    category: USB
+    description: Contains a console test application and a series of iterative drivers for both KMDF and UMDF version 1.
+    samplefwlink: https://go.microsoft.com/fwlink/?linkid=856746
+--->
+
+
 WDF Sample Driver Learning Lab for OSR USB-FX2
 ==============================================
 

--- a/video/KMDOD/README.md
+++ b/video/KMDOD/README.md
@@ -1,3 +1,12 @@
+<!---
+    name: Kernel mode display-only miniport driver (KMDOD) sample
+    platform: WDM
+    language: cpp
+    category: Video
+    description: Implements most DDIs that a display-only miniport driver should provide to the Windows Display Driver Model (WDDM).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620317
+--->
+
 Kernel mode display-only miniport driver (KMDOD) sample
 =======================================================
 

--- a/video/pixlib/README.md
+++ b/video/pixlib/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: PixLib sample
+    platform: LIB
+    language: cpp
+    category: Video
+    description: Demonstrates how to implement the CPixel class for use by a display driver.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618005
+--->
+
+
 PixLib sample
 =============
 

--- a/wia/README.md
+++ b/wia/README.md
@@ -1,4 +1,14 @@
-﻿Windows Image Acquisition (WIA) Driver Samples
+﻿<!---
+    name: Windows Image Acquisition (WIA) Driver Samples
+    platform: WDM
+    language: cpp
+    category: Image Scan
+    description: Contains samples and test tools for Windows Image Acquisition (WIA), a driver architecture and user interface for acquiring images from still image devices such as scanners.
+    samplefwlink: https://go.microsoft.com/fwlink/p/?linkid=856747
+--->
+
+
+Windows Image Acquisition (WIA) Driver Samples
 ==============================================
 
 The Windows Image Acquisition driver sample set contains samples and test tools for Windows Image Acquisition (WIA), a driver architecture and user interface for acquiring images from still image devices such as scanners.

--- a/wmi/wmiacpi/README.md
+++ b/wmi/wmiacpi/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WMIACPI Sample
+    platform: WDM
+    language: cpp
+    category: WMI ACPI
+    description: Contains ACPI BIOS and WMI sample code that enables instrumentation of the ACPI BIOS from within ACPI Source Language (ASL) code.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618006
+--->
+
+
 WMI ACPI Sample
 ===============
 

--- a/wmi/wmisamp/README.md
+++ b/wmi/wmisamp/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WmiSamp WMI Provider
+    platform: KMDF
+    language: cpp
+    category: WMI
+    description: Demonstrates how to register WMI providers in KMDF, create provider instances, and handle WMI queries sent to a device.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618007
+--->
+
+
 Sample KMDF Driver Implementing a WMI Data Provider
 ===================================================
 

--- a/wpd/WpdBasicHardwareDriver/README.md
+++ b/wpd/WpdBasicHardwareDriver/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WPD Basic Hardware Sample Driver
+    platform: UMDF1
+    language: cpp
+    category: WDP
+    description: Supports nine sensor devices that integrate with the Parallax BS2 programmable microcontroller.           
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=620318
+--->
+
+
 WPD Basic Hardware Sample Driver (UMDF Version 1)
 =================================================
 

--- a/wpd/WpdHelloWorldDriver/README.md
+++ b/wpd/WpdHelloWorldDriver/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WPD Hello World Sample 
+    platform: UMDF1
+    language: cpp
+    category: WPD
+    description: Supports four objects: a device object, a storage object, a folder object, and a file object. 
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618008
+--->
+
+
 WPDHelloWorld sample driver for portable devices
 ================================================
 

--- a/wpd/WpdMultiTransportDriver/README.md
+++ b/wpd/WpdMultiTransportDriver/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WPD multi-transport sample driver
+    platform: UMDF1
+    language: cpp
+    category: WPD
+    description: Demonstrates how to extend the WpdHelloWorldDriver for a device that supports multiple transports.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618009
+--->
+
+
 WPD multi-transport sample driver
 =================================
 

--- a/wpd/WpdServiceSampleDriver/README.md
+++ b/wpd/WpdServiceSampleDriver/README.md
@@ -1,11 +1,17 @@
-WPD multi-transport sample driver
+<!---
+    name: WPD service sample driver
+    platform: UMDF1
+    language: cpp
+    category: WPD
+    description: Demonstrates how to extend the WpdHelloWorldDriver sample so that it supports a simulated device with a Contacts device service.
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618010
+--->
+
+
+WPD service sample driver
 =================================
 
-The WpdMultiTransportDriver sample demonstrates how you could extend the WpdHelloWorldDriver for a device that supports multiple transports. A transport is a protocol over which a portable device communicates with a computer. Example transports include Internet Protocol (IP), Bluetooth, and USB.
-
-A number of portable devices now support multiple transports. For example, a number of cell phones support both Bluetooth and USB. Windows supports a multitransport driver model that ensures that only one node appears for each device.
-
-For a complete description of this sample and its underlying code and functionality, refer to the [WPD MultiTransport Driver](http://msdn.microsoft.com/en-us/library/windows/hardware/ff597709) description in the Windows Driver Kit documentation.
+Demonstrates how to extend the WpdHelloWorldDriver sample so that it supports a simulated device with a Contacts device service.
 
 Related topics
 --------------

--- a/wpd/WpdWudfSampleDriver/README.md
+++ b/wpd/WpdWudfSampleDriver/README.md
@@ -1,3 +1,13 @@
+<!---
+    name: WPD WUDF sample driver
+    platform: UMDF1
+    language: cpp
+    category: WPD
+    description: Demonstrates virtually all aspects of the WPD device driver interface (DDI).
+    samplefwlink: http://go.microsoft.com/fwlink/p/?LinkId=618011
+--->
+
+
 WPD WUDF sample driver
 ======================
 


### PR DESCRIPTION
Added driver sample metadata in a comment block in each sample's README.md file. This metadata will be used to implement search functionality on the Hardware Dev Center [Windows driver code samples](https://developer.microsoft.com/en-us/windows/hardware/drivers-code-samples) page. See the [Code samples](https://developer.microsoft.com/en-us/windows/samples) page on the Windows Dev Center as an example of how this will be implemented.