### PR TITLE
Fix general/ioctl/kmdf/exe load wrong version of wdf controller dll.

### DIFF
--- a/general/ioctl/kmdf/exe/testapp.c
+++ b/general/ioctl/kmdf/exe/testapp.c
@@ -198,7 +198,8 @@ GetCoinstallerVersion(
     VOID
     )
 {
-    if (FAILED( StringCchPrintf(G_coInstallerVersion,
+    if (!G_versionSpecified &&
+        FAILED( StringCchPrintf(G_coInstallerVersion,
                                 MAX_VERSION_SIZE,
                                 "%02d%03d",    // for example, "01009"
                                 KMDF_VERSION_MAJOR,


### PR DESCRIPTION
At installer.c `LoadWdfCoInstaller` function always get wrong coinstallerVersion 01011, even used `-v version` command line args.