### PR TITLE
Update DV-FailDriver-WDM sample to correctly create a driver package.

### DIFF
--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
@@ -1,6 +1,6 @@
 ;/*++
 ;
-;Copyright (c) 1990-2015 Microsoft Corporation All rights Reserved
+;Copyright (c) 1990-2017 Microsoft Corporation All rights Reserved
 ;
 ;Module Name:
 ;
@@ -16,7 +16,7 @@ Signature="$WINDOWS NT$"
 Class=System
 ClassGuid={4d36e97d-e325-11ce-bfc1-08002be10318}
 Provider="Sample Provider"
-DriverVer=07/29/2015,10.0.0.0
+DriverVer=12/12/2017,10.0.0.1
 CatalogFile=Defect_Toastmon.cat
 
 [DestinationDirs]
@@ -26,19 +26,19 @@ DefaultDestDir = 12
 ; ================= Device Install section =====================
 
 [Manufacturer]
-%ManufacturerString%=MSFT,NTx86, NTamd64, NTARM, NTARM64
+%ManufacturerString%=Sample_Manufacturer,NTx86, NTamd64, NTARM, NTARM64
 
 ; For XP and later
-[MSFT.NTx86]
+[Sample_Manufacturer.NTx86]
 %Defect_ToastMon.DRVDESC%=Defect_ToastMon_Inst,root\defect_toastmon
 
-[MSFT.NTARM]
+[Sample_Manufacturer.NTARM]
 %Defect_ToastMon.DRVDESC%=Defect_ToastMon_Inst,root\defect_toastmon
 
-[MSFT.NTARM64]
+[Sample_Manufacturer.NTARM64]
 %Defect_ToastMon.DRVDESC%=Defect_ToastMon_Inst,root\defect_toastmon
 
-[MSFT.NTamd64]
+[Sample_Manufacturer.NTamd64]
 %Defect_ToastMon.DRVDESC%=Defect_ToastMon_Inst,root\defect_toastmon
 
 [Defect_ToastMon_Inst.NT]

--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.vcxproj
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{50D75FD5-F47F-4289-98ED-B4AF87F5074D}</ProjectGuid>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
-    <SupportsPackaging>false</SupportsPackaging>
+    <SupportsPackaging>true</SupportsPackaging>
     <RequiresPackageProject>true</RequiresPackageProject>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
@@ -90,7 +90,7 @@
     <TargetName>defect_toastmon</TargetName>
   </PropertyGroup>
   <ItemGroup>
-    <FilesToPackage Include="..\defect_toastmon.inf" />
+    <FilesToPackage Include=".\defect_toastmon.inf" />
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.vcxproj.Filters
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.vcxproj.Filters
@@ -19,11 +19,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <FilesToPackage Include="..\defect_toastmon.inf">
-      <Filter>Driver Files</Filter>
-    </FilesToPackage>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="..\defect_toastmon.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -35,5 +30,10 @@
     <ResourceCompile Include="..\defect_toastmon.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="*.inf">
+      <Filter>Driver Files</Filter>
+    </Inf>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The DV-FailDriver-WDM sample can't be properly deployed today, due to a combination of errors in the INF and project settings.

This PR cleans up the INF and updates the project settings to correctly create a catalog file and driver package.