### PR TITLE
Fix segfault in FillDeviceInfo

### DIFF
--- a/hid/hclient/hclient.c
+++ b/hid/hclient/hclient.c
@@ -467,21 +467,23 @@ DumpValueInfo(
 BOOL
 CLM_AttachConsole()
 {
-    HANDLE  stdOut = INVALID_HANDLE_VALUE;
-    int     osfStdOut = -1;
     FILE    *cStdOut = NULL;
 
     if (AttachConsole(ATTACH_PARENT_PROCESS))
     {
-        stdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+#if _MSC_VER >= 1700
+        freopen_s(&cStdOut, "CON", "w", stdout);
+#else
+        HANDLE stdOut = GetStdHandle(STD_OUTPUT_HANDLE);
         if (INVALID_HANDLE_VALUE != stdOut)
         {
-            osfStdOut = _open_osfhandle((intptr_t)stdOut, _O_TEXT);
+            int osfStdOut = _open_osfhandle((intptr_t)stdOut, _O_TEXT);
             if (-1 != osfStdOut)
             {
                 cStdOut = _fdopen(osfStdOut, "w");
             }
         }
+#endif
     }
 
     if (NULL == cStdOut)

--- a/hid/hclient/pnp.c
+++ b/hid/hclient/pnp.c
@@ -662,12 +662,12 @@ FillDeviceInfo(
         }
 
         if(FAILED(ULongAdd((HidDevice->Caps).NumberOutputButtonCaps ,
-                                     (valueCaps->Range).UsageMax, &tmpSum))) 
+                                     (buttonCaps->Range).UsageMax, &tmpSum))) 
         {
             goto Done;
         }        
 
-        if((valueCaps->Range).UsageMin == tmpSum)
+        if((buttonCaps->Range).UsageMin == tmpSum)
         {
             goto Done;
         }


### PR DESCRIPTION
The loop over all buttonCaps erroneously references valueCaps fields which seems to be a cut/copy/paste error. This causes a segfault for my setup.