### PR TITLE
VSTS 15439953

### DIFF
--- a/filesys/miniFilter/MetadataManager/support.c
+++ b/filesys/miniFilter/MetadataManager/support.c
@@ -155,7 +155,7 @@ FmmIsImplicitVolumeLock(
 
 Routine Description:
 
-    This routine determines if an open is a implcit volume lock.
+    This routine determines if an open is a implicit volume lock.
 
 Arguments
     
@@ -163,13 +163,13 @@ Arguments
                             declares the requested operation.
 
     IsLock                - Supplies a pointer to a user allocated boolean
-                            which is used to tell the user wheather the
+                            which is used to tell the user whether the
                             operation is an implied volume lock.
 Return Value:
  
-    Returns STATUS_SUCCESS if the the function determined wheather or not
+    Returns STATUS_SUCCESS if the the function determined whether or not
     the operation was a volume lock. On STATUS_SUCCESS it is safe to check 
-    IsLock to get the answer. Otherwise, the check failed and we dont know
+    IsLock to get the answer. Otherwise, the check failed and we don't know
     if it is a lock or not. STATUS_INVALID_PARAMETER indicates that the
     volume's file system type is unrecognized by the check function. This is
     an error code.
@@ -179,7 +179,6 @@ Return Value:
     NTSTATUS status = STATUS_SUCCESS;
     PFMM_INSTANCE_CONTEXT instanceContext = NULL;
     USHORT shareAccess;
-    ACCESS_MASK prevAccess;
 
     PAGED_CODE();
 
@@ -201,27 +200,18 @@ Return Value:
     FLT_ASSERT( instanceContext != NULL );
 
     //
-    //  Now check to see if the open is an implied volume lock
-    //  on this filesystem.
+    //  Now check to see if the open is an implicit volume lock.  It is if the
+    //  caller doesn't want to allow other handles on the volume to be open for
+    //  write and/or delete (i.e. they must be read-only).  We must close our
+    //  handle to our metadata file so that the volume open can succeed.
     //
 
     shareAccess = Cbd->Iopb->Parameters.Create.ShareAccess;
-    prevAccess = Cbd->Iopb->Parameters.Create.SecurityContext->DesiredAccess;
 
     switch (instanceContext->FilesystemType) {
 
         case FLT_FSTYPE_REFS:
-            *IsLock = ((!BooleanFlagOn( shareAccess, FILE_SHARE_WRITE | FILE_SHARE_DELETE)) &&
-                       (BooleanFlagOn( prevAccess,(FILE_WRITE_DATA | FILE_APPEND_DATA) )));
-            status = STATUS_SUCCESS;
-            break;
-
         case FLT_FSTYPE_NTFS:
-            *IsLock = ((!BooleanFlagOn( shareAccess, FILE_SHARE_WRITE | FILE_SHARE_DELETE)) &&
-                          (BooleanFlagOn( prevAccess,(FILE_WRITE_DATA | FILE_APPEND_DATA) )));
-            status = STATUS_SUCCESS;
-            break;
-
         case FLT_FSTYPE_FAT:
             *IsLock = (!BooleanFlagOn( shareAccess, FILE_SHARE_WRITE | FILE_SHARE_DELETE));
             status = STATUS_SUCCESS;


### PR DESCRIPTION
With MetadataManager attached to a volume, open a DASD handle for GENERIC_READ, FILE_SHARE_READ.  MetadataManager should close its handle, but does not.  It is checking for DesiredAccess in addition to ShareMode, which is incorrect.  It should only check for ShareMode.

