### PR TITLE
Bugfix: don't set Top Level IRP if locking failed

### DIFF
--- a/filesys/cdfs/resrcsup.c
+++ b/filesys/cdfs/resrcsup.c
@@ -161,10 +161,15 @@ Return Value:
 {
     PAGED_CODE();
 
+    if (!ExAcquireResourceSharedLite( Fcb->Resource, Wait )) {
+
+        return FALSE;
+    }
+
     NT_ASSERT(IoGetTopLevelIrp() == NULL);
     IoSetTopLevelIrp((PIRP)FSRTL_CACHE_TOP_LEVEL_IRP);
 
-    return ExAcquireResourceSharedLite( Fcb->Resource, Wait );
+    return TRUE;
 }
 
 


### PR DESCRIPTION
Hi,

This pull request fixes a bug that can be easily uncovered when using a CDFS checked build. CdAcquireForCache() sets the Top Level IRP before even attempting to lock the FCB resource. In case locking fails, the Top Level IRP is left set, and when a next call to CdAcquireForCache() is made, the assert is hit.
This commit fixes hit by setting the Top Level IRP after locking succeed (as done in FastFAT, for instance).

Cheers,
Pierre