### PR TITLE
Remove BaseAddress property from all projects to avoid warning LNK4281

### DIFF
--- a/general/SystemDma/wdm/exe/SystemDmaApp.vcxproj
+++ b/general/SystemDma/wdm/exe/SystemDmaApp.vcxproj
@@ -99,9 +99,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -115,9 +112,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -131,9 +125,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -147,9 +138,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/general/cancel/exe/canclapp.vcxproj
+++ b/general/cancel/exe/canclapp.vcxproj
@@ -101,9 +101,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x0400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ResourceCompile>
@@ -119,9 +116,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x0400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ResourceCompile>
@@ -137,9 +131,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x0400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ResourceCompile>
@@ -155,9 +146,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);..\sys</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x0400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="install.c" />

--- a/general/event/exe/event.vcxproj
+++ b/general/event/exe/event.vcxproj
@@ -101,9 +101,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\wdm</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -119,9 +116,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\wdm</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -137,9 +131,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\wdm</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -155,9 +146,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\wdm</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x400000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="eventtest.c" />

--- a/general/ioctl/wdm/exe/ioctlapp.vcxproj
+++ b/general/ioctl/wdm/exe/ioctlapp.vcxproj
@@ -99,9 +99,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -115,9 +112,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -131,9 +125,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -147,9 +138,6 @@
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\</AdditionalIncludeDirectories>
     </Midl>
-    <Link>
-      <BaseAddress>0x04000000</BaseAddress>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/general/pcidrv/test/myping.vcxproj
+++ b/general/pcidrv/test/myping.vcxproj
@@ -101,7 +101,6 @@
     </Midl>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);setupapi.lib;wsock32.lib;ws2_32.lib;ole32.lib</AdditionalDependencies>
-      <BaseAddress>0x01000000</BaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -118,7 +117,6 @@
     </Midl>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);setupapi.lib;wsock32.lib;ws2_32.lib;ole32.lib</AdditionalDependencies>
-      <BaseAddress>0x01000000</BaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -135,7 +133,6 @@
     </Midl>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);setupapi.lib;wsock32.lib;ws2_32.lib;ole32.lib</AdditionalDependencies>
-      <BaseAddress>0x01000000</BaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -152,7 +149,6 @@
     </Midl>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);setupapi.lib;wsock32.lib;ws2_32.lib;ole32.lib</AdditionalDependencies>
-      <BaseAddress>0x01000000</BaseAddress>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/hid/firefly/app/flicker.vcxproj
+++ b/hid/firefly/app/flicker.vcxproj
@@ -110,7 +110,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
-
       <AdditionalDependencies>%(AdditionalDependencies);.\..\lib\$(IntDir)\luminous.lib;ole32.lib;oleaut32.lib;wbemuuid.lib</AdditionalDependencies>
     </Link>
     <ClCompile>

--- a/hid/firefly/app/flicker.vcxproj
+++ b/hid/firefly/app/flicker.vcxproj
@@ -89,7 +89,6 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <BaseAddress>0x400000</BaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies);.\..\lib\$(IntDir)\luminous.lib;ole32.lib;oleaut32.lib;wbemuuid.lib</AdditionalDependencies>
     </Link>
     <ClCompile>
@@ -111,7 +110,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
-      <BaseAddress>0x400000</BaseAddress>
+
       <AdditionalDependencies>%(AdditionalDependencies);.\..\lib\$(IntDir)\luminous.lib;ole32.lib;oleaut32.lib;wbemuuid.lib</AdditionalDependencies>
     </Link>
     <ClCompile>
@@ -133,7 +132,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>
-      <BaseAddress>0x400000</BaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies);.\..\lib\$(IntDir)\luminous.lib;ole32.lib;oleaut32.lib;wbemuuid.lib</AdditionalDependencies>
     </Link>
     <ClCompile>
@@ -155,7 +153,6 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Link>
-      <BaseAddress>0x400000</BaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies);.\..\lib\$(IntDir)\luminous.lib;ole32.lib;oleaut32.lib;wbemuuid.lib</AdditionalDependencies>
     </Link>
     <ClCompile>

--- a/hid/vhidmini2/app/testvhid.vcxproj
+++ b/hid/vhidmini2/app/testvhid.vcxproj
@@ -90,7 +90,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hid.lib;mincore.lib;comdlg32.lib</AdditionalDependencies>
-      <BaseAddress>0x400000</BaseAddress>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\inc</AdditionalIncludeDirectories>
@@ -110,7 +109,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hid.lib;mincore.lib;comdlg32.lib</AdditionalDependencies>
-      <BaseAddress>0x400000</BaseAddress>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\inc</AdditionalIncludeDirectories>
@@ -130,7 +128,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hid.lib;mincore.lib;comdlg32.lib</AdditionalDependencies>
-      <BaseAddress>0x400000</BaseAddress>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\inc</AdditionalIncludeDirectories>
@@ -150,7 +147,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);hid.lib;mincore.lib;comdlg32.lib</AdditionalDependencies>
-      <BaseAddress>0x400000</BaseAddress>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\inc</AdditionalIncludeDirectories>

--- a/nfc/Simulator/Src/NfcDriverSim.vcxproj
+++ b/nfc/Simulator/Src/NfcDriverSim.vcxproj
@@ -215,26 +215,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Link>
-      <BaseAddress>0x2000000</BaseAddress>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Link>
-      <BaseAddress>0x2000000</BaseAddress>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Link>
-      <BaseAddress>0x2000000</BaseAddress>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Link>
-      <BaseAddress>0x2000000</BaseAddress>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);UNICODE;_UNICODE;WPP_MACRO_USE_KM_VERSION_FOR_UM=1</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>


### PR DESCRIPTION
Under x64 using VIsual Studio 15.5.4+, these projects now throw the warning LNK4281 "undesirable base address 0x400000 for x64 image; set base address above 4GB for best ASLR optimization".

