### PR TITLE
Serial driver bug fix.

### DIFF
--- a/serial/serial/utils.c
+++ b/serial/serial/utils.c
@@ -213,10 +213,19 @@ Return Value:
 
             reqContext = SerialGetRequestContext(oldRequest);
 
-            SerialCompleteRequest(oldRequest,
-                                  reqContext->Status,
-                                  reqContext->Information);
-        }
+            if(reqContext->CancelRoutine) {
+
+                status = SerialClearCancelRoutine(oldRequest, TRUE);
+
+            }
+
+            if(status != STATUS_CANCELLED) {
+
+                SerialCompleteRequest(oldRequest,
+                                       reqContext->Status,
+                                       reqContext->Information);
+            }
+         }
     }
 }
 


### PR DESCRIPTION
If a request has a cancel routine, the cancel routine need to be cleared before completion otherwise the queue get corrupted.