### PR TITLE
Fix some log lines in SimRep

### DIFF
--- a/filesys/miniFilter/simrep/simrep.c
+++ b/filesys/miniFilter/simrep/simrep.c
@@ -1174,7 +1174,7 @@ Return Value:
     PAGED_CODE();
 
     DebugTrace( DEBUG_TRACE_ALL_IO,
-                ("[SimRep]: SimRepQueryOpen -> Enter (Cbd = %p, FileObject = %p)\n",
+                ("[SimRep]: SimRepPreNetworkQueryOpen -> Enter (Cbd = %p, FileObject = %p)\n",
                  Cbd,
                  FltObjects->FileObject) );
 
@@ -1335,7 +1335,7 @@ SimRepPreNetworkQueryOpenCleanup:
         //
 
         DebugTrace( DEBUG_TRACE_ERROR,
-                    ("[SimRep]: SimRepPreCreate -> Failed with status 0x%x \n",
+                    ("[SimRep]: SimRepPreNetworkQueryOpen -> Failed with status 0x%x \n",
                     status) );
 
         Cbd->IoStatus.Status = status;


### PR DESCRIPTION
This PR simply fixes some incorrect log lines in SimRepPreNetworkQueryOpen 