### PR TITLE
wfpsampler: fix null reference

### DIFF
--- a/network/trans/WFPSampler/sys/ClassifyFunctions_BasicPacketModificationCallouts.cpp
+++ b/network/trans/WFPSampler/sys/ClassifyFunctions_BasicPacketModificationCallouts.cpp
@@ -4966,8 +4966,6 @@ NTSTATUS PerformBasicPacketModificationAtOutboundTransport(_In_ CLASSIFY_DATA** 
 
    *ppInjectionData = 0;
 
-   pSendParams = 0;
-
    if(FWPS_IS_METADATA_FIELD_PRESENT(pMetadata,
                                      FWPS_METADATA_FIELD_TRANSPORT_ENDPOINT_HANDLE))
       endpointHandle = pMetadata->transportEndpointHandle;


### PR DESCRIPTION
Since 0 is assigned to pSendParams, it becomes BSOD with the following code.

```cpp
   if(FWPS_IS_METADATA_FIELD_PRESENT(pMetadata,
                                     FWPS_METADATA_FIELD_TRANSPORT_CONTROL_DATA))
   {
      pSendParams->controlData       = pMetadata->controlData;
      pSendParams->controlDataLength = pMetadata->controlDataLength;
   }
```