### PR TITLE
filesys/cdfs: properly check for legal names in CdIsLegalName()

### DIFF
--- a/filesys/cdfs/namesup.c
+++ b/filesys/cdfs/namesup.c
@@ -404,7 +404,13 @@ Return Value:
          Wchar < Add2Ptr( FileName->Buffer, FileName->Length, PWCHAR );
          Wchar++) {
 
-        if ((*Wchar < 0xff) &&
+        //
+        // Check whether ASCII characters are legal.
+        // We will consider the rest of the characters
+        // (extended ASCII and unicode) as legal.
+        //
+
+        if ((*Wchar < 0x80) &&
             !FsRtlIsAnsiCharacterLegalHpfs( *Wchar, FALSE ) &&
             (*Wchar != L'"') &&
             (*Wchar != L'<') &&


### PR DESCRIPTION
Up to now, it was working by chance. Indeed, due to the invalid
ASCII check performed before calling FsRtlIsAnsiCharacterLegalHpfs(), the
macro is improperly called and overruns the FsRtlLegalAnsiCharacterArray
buffer. Fortunately, up to now, right after that buffer in kernel binary
there are strings which are more or less consistent with the flags that
are expected by the macro, causing a decent behavior of
FsRtlIsAnsiCharacterLegalHpfs() even for extended ASCII characters
(whereas FsRtlIsAnsiCharacterLegalHpfs() is only designed for ASCII
characters). But this is a totally out of control and wrong behavior.
A single change in the way the kernel was built could have caused the
CDFS driver not to work as previously.

I have made the choice to allow any extended ASCII character as done
for the unicode characters. This is a good compromise to avoid drastic
regressions for users having extended ASCII characters in their CD
file names.