### PR TITLE
Fix IOCTL_BTHX_READ/WRITE_HCI parameter sizes

### DIFF
--- a/bluetooth/serialhcibus/Fdo.c
+++ b/bluetooth/serialhcibus/Fdo.c
@@ -1898,7 +1898,7 @@ Return Value:
         DoTrace(LEVEL_INFO, TFLAG_IOCTL,(" IOCTL_BTHX_WRITE_HCI ---------->"));
         // Validate input and output parameters
         if (!InBuffer || InBufferSize < sizeof(BTHX_HCI_READ_WRITE_CONTEXT) ||
-            !OutBuffer || OutBufferSize != sizeof(BTHX_HCI_PACKET_TYPE))
+            !OutBuffer || OutBufferSize != sizeof(ULONG))
         {
             Status = STATUS_INVALID_PARAMETER;
             DoTrace(LEVEL_ERROR, TFLAG_IOCTL,(" IOCTL_BTHX_WRITE_HCI %!STATUS!", Status));
@@ -1934,7 +1934,7 @@ Return Value:
     case IOCTL_BTHX_READ_HCI:
         DoTrace(LEVEL_INFO, TFLAG_IOCTL,(" IOCTL_BTHX_READ_HCI <----------"));
         // Validate input and output parameters
-        if (!InBuffer || InBufferSize != sizeof(BTHX_HCI_PACKET_TYPE) ||
+        if (!InBuffer || InBufferSize < sizeof(UCHAR) ||
             !OutBuffer || OutBufferSize < sizeof(BTHX_HCI_READ_WRITE_CONTEXT))
         {
             Status = STATUS_INVALID_PARAMETER;
@@ -1942,7 +1942,7 @@ Return Value:
             break;
         }
 
-        PacketType = *((BTHX_HCI_PACKET_TYPE *) InBuffer);
+        PacketType = (BTHX_HCI_PACKET_TYPE) *((UCHAR *) InBuffer);
 
         if (!BTHX_VALID_READ_PACKET_TYPE(PacketType))
         {


### PR DESCRIPTION
WRITE_HCI's second parameter is a ULONG, not a BTHX_HCI_PACKET_TYPE. These two types may or may not be of equal size, depending on the compiler.

READ_HCI is specified as taking a UCHAR representing the type. This driver
instead uses an enum type, with an implementation-defined size. Properly convert to this type from the specified UCHAR, and don't rely on the caller passing an enum-sized buffer.