### PR TITLE
Fix changing and reading FAT labels with leading 0xE5 byte in fastfat.sys

### DIFF
--- a/filesys/fastfat/fsctrl.c
+++ b/filesys/fastfat/fsctrl.c
@@ -1411,22 +1411,34 @@ Return Value:
 
         if (Dirent != NULL) {
 
+            UCHAR OemBuffer[11];
             OEM_STRING OemString;
             UNICODE_STRING UnicodeString;
+
+            OemString.Buffer = (PCHAR)&OemBuffer[0];
+            OemString.MaximumLength = 11;
+
+            RtlCopyMemory( OemString.Buffer, Dirent->FileName, 11 );
+
+            //
+            //  Translate the first character from 0x5 to 0xe5.
+            //
+
+            if (OemString.Buffer[0] == FAT_DIRENT_REALLY_0E5) {
+
+                OemString.Buffer[0] = 0xe5;
+            }
 
             //
             //  Compute the length of the volume name
             //
 
-            OemString.Buffer = (PCHAR)&Dirent->FileName[0];
-            OemString.MaximumLength = 11;
-
             for ( OemString.Length = 11;
                   OemString.Length > 0;
                   OemString.Length -= 1) {
 
-                if ( (Dirent->FileName[OemString.Length-1] != 0x00) &&
-                     (Dirent->FileName[OemString.Length-1] != 0x20) ) { break; }
+                if ( (OemString.Buffer[OemString.Length-1] != 0x00) &&
+                     (OemString.Buffer[OemString.Length-1] != 0x20) ) { break; }
             }
 
             UnicodeString.MaximumLength = MAXIMUM_VOLUME_LABEL_LENGTH;
@@ -7794,6 +7806,7 @@ Return Value:
     PDIRENT Dirent;
     PDIRENT TerminationDirent;
     ULONG VolumeLabelLength;
+    UCHAR OemBuffer[11];
     OEM_STRING OemString;
     UNICODE_STRING UnicodeString;
 
@@ -7840,19 +7853,30 @@ Return Value:
     }
 
 
+    OemString.Buffer = (PCHAR)&OemBuffer[0];
+    OemString.MaximumLength = 11;
+
+    RtlCopyMemory( OemString.Buffer, Dirent->FileName, 11 );
+
+    //
+    //  Translate the first character from 0x5 to 0xe5.
+    //
+
+    if (OemString.Buffer[0] == FAT_DIRENT_REALLY_0E5) {
+
+        OemString.Buffer[0] = 0xe5;
+    }
+
     //
     //  Compute the length of the volume name
     //
-
-    OemString.Buffer = (PCHAR)&Dirent->FileName[0];
-    OemString.MaximumLength = 11;
 
     for ( OemString.Length = 11;
           OemString.Length > 0;
           OemString.Length -= 1) {
 
-        if ( (Dirent->FileName[OemString.Length-1] != 0x00) &&
-             (Dirent->FileName[OemString.Length-1] != 0x20) ) { break; }
+        if ( (OemString.Buffer[OemString.Length-1] != 0x00) &&
+             (OemString.Buffer[OemString.Length-1] != 0x20) ) { break; }
     }
 
     UnicodeString.MaximumLength = sizeof( UnicodeBuffer );

--- a/filesys/fastfat/volinfo.c
+++ b/filesys/fastfat/volinfo.c
@@ -1154,6 +1154,15 @@ Return Value:
         if (OemLabel.Length > 0) {
 
             //
+            //  Translate the first character from 0xe5 to 0x5.
+            //
+
+            if ((UCHAR)OemLabel.Buffer[0] == 0xe5) {
+
+                OemLabel.Buffer[0] = FAT_DIRENT_REALLY_0E5;
+            }
+
+            //
             //  Locate the volume label if there already is one
             //
 


### PR DESCRIPTION
FAT Volume Label is stored in the root directory entry and therefore when
setting new Volume Label with leading 0xE5 byte it first needs to be
converted to 0x05 byte. This step is also required by Microsoft FAT
specification (fatgen103.doc) and also applied for all other files and
directories. But not for volume label yet. First byte 0xE5 in directory
entry means that entry is removed.

Similarly, when reading Volume Label from the root directory, leading byte
0x05 first needs to be converted to 0xE5 and then later processed. This is
reverse operation as described in previous paragraph.

FAT Volume Label is converted from Unicode to bytes according to OEM code
page. OEM code page is configured in Language for non-Unicode applications
settings in Country/Region settings.

When it is set to English (United Kingdom), then OEM code page is 850. And
in 850 is Unicode LATIN CAPITAL LETTER O WITH TILDE represented as 0xE5.

Therefore this pull request fixes setting FAT label "Õ" when regional
settings are set to English (United Kingdom).