### PR TITLE
Update ClassifyFunctions_BasicPacketModificationCallouts.cpp

### DIFF
--- a/network/trans/WFPSampler/sys/ClassifyFunctions_BasicPacketModificationCallouts.cpp
+++ b/network/trans/WFPSampler/sys/ClassifyFunctions_BasicPacketModificationCallouts.cpp
@@ -4979,8 +4979,8 @@ NTSTATUS PerformBasicPacketModificationAtOutboundTransport(_In_ CLASSIFY_DATA** 
    if(FWPS_IS_METADATA_FIELD_PRESENT(pMetadata,
                                      FWPS_METADATA_FIELD_TRANSPORT_CONTROL_DATA))
    {
-      pSendParams->controlData       = pMetadata->controlData;
-      pSendParams->controlDataLength = pMetadata->controlDataLength;
+      pCompletionData->pSendParams->controlData       = pMetadata->controlData;
+      pCompletionData->pSendParams->controlDataLength = pMetadata->controlDataLength;
    }
 
    pAddressValue = KrnlHlprFwpValueGetFromFwpsIncomingValues(pClassifyValues,


### PR DESCRIPTION
fix null pointer deref.  pSendParams has moved under pCompletionData and any further use must be done from this struct