### PR TITLE
Removed incorrect file handle check

### DIFF
--- a/general/ioctl/kmdf/exe/install.c
+++ b/general/ioctl/kmdf/exe/install.c
@@ -702,9 +702,7 @@ SetupDriverName(
     //
     // Close open file handle.
     //
-    if (fileHandle) {
-        CloseHandle(fileHandle);
-    }
+    CloseHandle(fileHandle);
 
     //
     // Indicate success.


### PR DESCRIPTION
The correct check would be `fileHandle != INVALID_HANDLE_VALUE`, but since the flow ensures that the handle is valid, the check is redundant.