### PR TITLE
Fix build failure for file encoding.

### DIFF
--- a/audio/sysvad/EndpointsCommon/MiniportAudioEngineNode.cpp
+++ b/audio/sysvad/EndpointsCommon/MiniportAudioEngineNode.cpp
@@ -57,9 +57,9 @@ Remarks:
     } KSAUDIOENGINE_DESCRIPTOR, *PKSAUDIOENGINE_DESCRIPTOR;
 
     The fields are defined as:
-    nHostPinId – The ID of the pin factory connected to the audio engine node that is intended for host processed audio data.  This is the pin factory on which a software audio engine will run.
-    nOffloadPinId – The ID of the pin factory connected to the audio engine node that is intended for offloaded streams.
-    nLoopbackPinId – The ID of the pin factory connected to the audio engine that is intended for supplying a post-mix loopback or reference stream.
+    nHostPinId - The ID of the pin factory connected to the audio engine node that is intended for host processed audio data.  This is the pin factory on which a software audio engine will run.
+    nOffloadPinId - The ID of the pin factory connected to the audio engine node that is intended for offloaded streams.
+    nLoopbackPinId - The ID of the pin factory connected to the audio engine that is intended for supplying a post-mix loopback or reference stream.
 
     All pin ids need to be unique for each audio engine node.
 


### PR DESCRIPTION
Replacing Unicode characters with ASCII charaters.

audio\sysvad\EndpointsCommon\MiniportAudioEngineNode.cpp(1,1): error C2220: the following warning is treated as an error
audio\sysvad\EndpointsCommon\MiniportAudioEngineNode.cpp(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss