### PR TITLE
SFloppy: Fool-proof 'NUMBER_OF_DRIVE_MEDIA_COMBINATIONS'

### DIFF
--- a/storage/sfloppy/src/floppy.c
+++ b/storage/sfloppy/src/floppy.c
@@ -207,7 +207,7 @@ DRIVE_MEDIA_CONSTANTS DriveMediaConstants[] =
 };
 
 
-#define NUMBER_OF_DRIVE_MEDIA_COMBINATIONS sizeof(DriveMediaConstants)/sizeof(DRIVE_MEDIA_CONSTANTS)
+#define NUMBER_OF_DRIVE_MEDIA_COMBINATIONS (sizeof(DriveMediaConstants)/sizeof(DriveMediaConstants[0]))
 
 //
 // floppy device data


### PR DESCRIPTION
* Add parentheses.
* Use name instead of type.