### PR TITLE
WDI sample: Use ExAllocatePool2 instead of ExAllocatePoolWithTag

### DIFF
--- a/network/wlan/WDI/PLATFORM/NDIS6/SDIO/N6SdioPlatformWindows.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/SDIO/N6SdioPlatformWindows.c
@@ -1006,17 +1006,15 @@ PlatformSdioGetProperty(
      	PSDBUS_REQUEST_PACKET psdrp = NULL;
 	NTSTATUS	status;
 	
-	psdrp = (PSDBUS_REQUEST_PACKET)ExAllocatePoolWithTag(NonPagedPool, sizeof(SDBUS_REQUEST_PACKET), '3278');
+	psdrp = (PSDBUS_REQUEST_PACKET)ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(SDBUS_REQUEST_PACKET), '3278');
 
 	if(!psdrp)
 		return STATUS_INSUFFICIENT_RESOURCES;
 	
-    	RtlZeroMemory(psdrp, sizeof(SDBUS_REQUEST_PACKET));
-
-    	psdrp->RequestFunction = SDRF_GET_PROPERTY;
-    	psdrp->Parameters.GetSetProperty.Property = Property;
-    	psdrp->Parameters.GetSetProperty.Buffer = Buffer;
-    	psdrp->Parameters.GetSetProperty.Length = Length;
+	psdrp->RequestFunction = SDRF_GET_PROPERTY;
+	psdrp->Parameters.GetSetProperty.Property = Property;
+	psdrp->Parameters.GetSetProperty.Buffer = Buffer;
+	psdrp->Parameters.GetSetProperty.Length = Length;
 
 	NdisAcquireSpinLock( &(pDevice->IrpSpinLock) );
 	RT_SDIO_INC_CMD_REF(pDevice);
@@ -1062,17 +1060,15 @@ PlatformSdioSetProperty(
 	PSDBUS_REQUEST_PACKET psdrp = NULL;
 	NTSTATUS	status;
 	
-	psdrp = (PSDBUS_REQUEST_PACKET)ExAllocatePoolWithTag(NonPagedPool, sizeof(SDBUS_REQUEST_PACKET), '3278');
+	psdrp = (PSDBUS_REQUEST_PACKET)ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(SDBUS_REQUEST_PACKET), '3278');
 
 	if(!psdrp)
 		return STATUS_INSUFFICIENT_RESOURCES;
 
-	RtlZeroMemory(psdrp, sizeof(SDBUS_REQUEST_PACKET));
-
-    	psdrp->RequestFunction = SDRF_SET_PROPERTY;
-    	psdrp->Parameters.GetSetProperty.Property = Property;
-    	psdrp->Parameters.GetSetProperty.Buffer = Buffer;
-    	psdrp->Parameters.GetSetProperty.Length = Length;    	
+	psdrp->RequestFunction = SDRF_SET_PROPERTY;
+	psdrp->Parameters.GetSetProperty.Property = Property;
+	psdrp->Parameters.GetSetProperty.Buffer = Buffer;
+	psdrp->Parameters.GetSetProperty.Length = Length;
 
 	NdisAcquireSpinLock( &(pDevice->IrpSpinLock) );
 	RT_SDIO_INC_CMD_REF(pDevice);
@@ -1409,14 +1405,12 @@ PlatformSdioCmd53ReadWriteMDL(
 	//
 	// Now allocate a request packet for the arguments of the command.
 	//	
-	psdrp = ExAllocatePoolWithTag(NonPagedPool, sizeof(SDBUS_REQUEST_PACKET), '3278');
+	psdrp = ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(SDBUS_REQUEST_PACKET), '3278');
 	if(!psdrp) 
 	{
 		RT_TRACE(COMP_IO, DBG_SERIOUS, ("PlatformSdioCmd53ReadWriteMDL(): Allocate sdrp fail!!\n"));
 		return rtstatus;
 	}
-		
-	RtlZeroMemory(psdrp, sizeof(SDBUS_REQUEST_PACKET));
 
 	psdrp->RequestFunction = SDRF_DEVICE_COMMAND;
 	psdrp->Parameters.DeviceCommand.Mdl = pmdl;
@@ -2985,7 +2979,7 @@ PrepareSdioAWBs(
 	//
 	// Allocate SD Request Packet
 	//
-	device->pAsynIoWriteSdrp = (PSDBUS_REQUEST_PACKET)ExAllocatePoolWithTag(NonPagedPool, sizeof(SDBUS_REQUEST_PACKET), '3278');
+	device->pAsynIoWriteSdrp = (PSDBUS_REQUEST_PACKET)ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(SDBUS_REQUEST_PACKET), '3278');
   	if(device->pAsynIoWriteSdrp == NULL)	
   		goto Error;
 	

--- a/network/wlan/WDI/PLATFORM/NDIS6/SDIO/N6Sdio_main.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/SDIO/N6Sdio_main.c
@@ -1489,10 +1489,9 @@ N6SdioInitTxQueue(
 	pDevice->RtNumTxQueue = SDIO_MAX_TX_QUEUE; // TX_HIQ, TX_MIQ and TX_LOQ	  
 
 	// Initialize the contexts in Tx Queue.
-	pDevice->RtTxQueue = 
-		(PRT_SDIO_TX_QUEUE)ExAllocatePoolWithTag(NonPagedPool, SDIO_MAX_TX_QUEUE*sizeof(RT_SDIO_TX_QUEUE), '3278' );
-	PlatformZeroMemory(pDevice->RtTxQueue, SDIO_MAX_TX_QUEUE*sizeof(RT_SDIO_TX_QUEUE));	
-  
+	pDevice->RtTxQueue =
+		(PRT_SDIO_TX_QUEUE)ExAllocatePool2(POOL_FLAG_NON_PAGED, SDIO_MAX_TX_QUEUE*sizeof(RT_SDIO_TX_QUEUE), '3278' );
+
 	if (pDevice->RtTxQueue != NULL) 
 	{
 

--- a/network/wlan/WDI/PLATFORM/NDIS6/SDIO/sdio.vcxproj
+++ b/network/wlan/WDI/PLATFORM/NDIS6/SDIO/sdio.vcxproj
@@ -336,13 +336,9 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'">
     <Link>
       <AdditionalDependencies>$(SolutionDir)COMMON\$(Configuration)\common.lib;$(SolutionDir)PLATFORM\NdisComm\$(Configuration)\NdisComm.lib;$(SolutionDir)\LIB\x86\hal.lib;$(SolutionDir)\LIB\x86\rtklibcom.lib;$(WindowsSDK_LibraryPath_x86)km\x86\ndis.lib;$(WindowsSDK_LibraryPath_x86)km\x86\ntoskrnl.lib;$(WindowsSDK_LibraryPath_x86)km\x86\sdbus.lib;$(WindowsSDK_LibraryPath_x86)km\x86\wlan\1.0\TlvGeneratorParser.lib;</AdditionalDependencies>
-      <Driver>
-      </Driver>
-      <TreatLinkerWarningAsErrors>
-      </TreatLinkerWarningAsErrors>
+      <!-- warning LNK4099: PDB 'rtklibcom.pdb' was not found with 'rtklibcom.lib(multichannels.obj)' -->
+      <AdditionalOptions>$(AdditionalOptions) /IGNORE:4099</AdditionalOptions>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <LinkStatus>
-      </LinkStatus>
     </Link>
     <ClCompile>
       <PreprocessorDefinitions>_X86_;DBG;NDIS60_MINIPORT;USE_KLOCKS=1;BINARY_COMPATIBLE=0;NDIS650_MINIPORT=1;NDIS640_MINIPORT=1;NDIS630_MINIPORT=1;NDIS620_MINIPORT=1;NDIS61_MINIPORT=1;NDIS_MINIPORT_DRIVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -425,6 +421,8 @@
       <DebugInformationFormat>None</DebugInformationFormat>
     </ClCompile>
     <Link>
+      <!-- warning LNK4099: PDB 'rtklibcom.pdb' was not found with 'rtklibcom.lib(multichannels.obj)' -->
+      <AdditionalOptions>$(AdditionalOptions) /IGNORE:4099</AdditionalOptions>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalDependencies>$(SolutionDir)COMMON\$(Configuration)\common.lib;$(SolutionDir)PLATFORM\NdisComm\$(Configuration)\NdisComm.lib;$(SolutionDir)\LIB\x86\hal.lib;$(SolutionDir)\LIB\x86\rtklibcom.lib;$(WindowsSDK_LibraryPath_x86)km\x86\ndis.lib;$(WindowsSDK_LibraryPath_x86)km\x86\ntoskrnl.lib;$(WindowsSDK_LibraryPath_x86)km\x86\sdbus.lib;$(WindowsSDK_LibraryPath_x86)km\x86\wlan\1.0\TlvGeneratorParser.lib;</AdditionalDependencies>
       <GenerateDebugInformation>
@@ -626,6 +624,8 @@
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <!-- warning LNK4099: PDB 'rtklibcom.pdb' was not found with 'rtklibcom.lib(multichannels.obj)' -->
+      <AdditionalOptions>$(AdditionalOptions) /IGNORE:4099</AdditionalOptions>
       <AdditionalDependencies>$(SolutionDir)COMMON\$(Configuration)\$(Platform)\common.lib;$(SolutionDir)PLATFORM\NdisComm\$(Configuration)\$(Platform)\NdisComm.lib;$(SolutionDir)\LIB\x64\hal.lib;$(SolutionDir)\LIB\x64\rtklibcom.lib;$(WindowsSDK_LibraryPath_x64)km\x64\ndis.lib;$(WindowsSDK_LibraryPath_x64)km\x64\ntoskrnl.lib;$(WindowsSDK_LibraryPath_x64)km\x64\sdbus.lib;$(WindowsSDK_LibraryPath_x64)km\x64\wlan\1.0\TlvGeneratorParser.lib;</AdditionalDependencies>
     </Link>
     <ProjectReference>

--- a/network/wlan/WDI/PLATFORM/NDIS6/WDI_Cmds.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/WDI_Cmds.c
@@ -3191,24 +3191,24 @@ Wdi_Set_Add_Pm_Protocol_Offload(
 
 
 	//2 DOT11 RSN REKey Offload
-	if(Params->DOT11RSNREKeyOffload.ProtocolOffloadId)
+	if(Params->DOT11RSNREKeyOffload.RsnKeyInfo.ProtocolOffloadId)
 	{
 		RT_TRACE(COMP_OID_SET, DBG_LOUD, ("ProtocolOffloadId = %d\n",
-			Params->DOT11RSNREKeyOffload.ProtocolOffloadId));
+			Params->DOT11RSNREKeyOffload.RsnKeyInfo.ProtocolOffloadId));
 
 		pMgntInfo->PowerSaveControl.PMProtocolOffloadIDs[eGTKOffloadIdx]
-			= Params->DOT11RSNREKeyOffload.ProtocolOffloadId;
+			= Params->DOT11RSNREKeyOffload.RsnKeyInfo.ProtocolOffloadId;
 
 		//Copy kck, kek
 		PlatformMoveMemory(&(pMgntInfo->PMDot11RSNRekeyPara.KCK),
-			Params->DOT11RSNREKeyOffload.KCK_CONTENT, 32);
+			&Params->DOT11RSNREKeyOffload.RsnKeyInfo.KCK_CONTENT, 32);
 
 		RT_PRINT_DATA( COMP_OID_SET, DBG_LOUD, ("KCK_CONTENT:\n"),
 			pMgntInfo->PMDot11RSNRekeyPara.KCK, 16);
 		RT_PRINT_DATA( COMP_OID_SET, DBG_LOUD, ("KEK_CONTENT:\n"),
 			pMgntInfo->PMDot11RSNRekeyPara.KEK, 16);
 
-		pMgntInfo->PMDot11RSNRekeyPara.KeyReplayCounter = Params->DOT11RSNREKeyOffload.ReplayCounter;
+		pMgntInfo->PMDot11RSNRekeyPara.KeyReplayCounter = Params->DOT11RSNREKeyOffload.RsnKeyInfo.ReplayCounter;
 
 		if(pPSC->RegGTKOffloadEnable)
 			pPSC->GTKOffloadEnable = TRUE;


### PR DESCRIPTION
- Use ExAllocatePool2 instead of ExAllocatePoolWithTag
- Fix build errors introduced in 2018