### PR TITLE
Add CA defect to SDV-FailDriver-WDM sample

### DIFF
--- a/tools/sdv/samples/SDV-FailDriver-WDM/driver/fail_driver1.c
+++ b/tools/sdv/samples/SDV-FailDriver-WDM/driver/fail_driver1.c
@@ -68,6 +68,9 @@ DriverAddDevice(
     UNREFERENCED_PARAMETER(PhysicalDeviceObject);
     
     PAGED_CODE();
+    
+    // Injected CA defect for C28171
+    PAGED_CODE();
 
     status = IoCreateDevice(DriverObject,                 
                             sizeof(DRIVER_DEVICE_EXTENSION), 


### PR DESCRIPTION
Add a simple C28171 code analysis for drivers violation to the SDV-FailDriver-WDM sample, so that we can use it to validate CA for drivers is working correctly.