### PR TITLE
Added configuration setting steps in Updated README.md 

### DIFF
--- a/print/OEM Printer Customization Plug-in Samples/README.md
+++ b/print/OEM Printer Customization Plug-in Samples/README.md
@@ -54,7 +54,13 @@ To build a driver solution using Windows 10 driver kit (Windows Driver Kit (WDK)
 
 1. Add all non-binary files (usually located in the \install directory of the sample) to the Package project
 
-    1. In the **Solution Explorer**, right click **Driver Files**
+    1. In the **Solution Explorer**, right click **Driver Files**. If you can't find **Driver Files** in this step, please change the "Platform Toolset" like below
+    
+        a. In the **Solution Explorer**, right click the Package project which you want to build and select **Properties**
+    
+        b. Select **General** under the **Configuration Properties**
+    
+        c. Change **Platform Toolset** to **WindowsKernelModeDriver10.0** or **WindowsUserModeDriver10.0**
 
     1. Select **Add**, then click **Existing Item**
 


### PR DESCRIPTION
I added statements about how to change Platform Toolset of the projects in Step 2-i.
When I used VS2017 and VS2019 to try to build the projects, Driver Files wasn't shown in the menu. 
So I think it is necessary to add these steps for people who download these good sample projects.
Could you help me check what I added is right or not?
Thank you

Best Regard,
Chao