### PR TITLE
msnmntr: Replace ExAllocatePoolWithTag with ExAllocatePoolZero

### DIFF
--- a/network/trans/msnmntr/sys/msnmntr.c
+++ b/network/trans/msnmntr/sys/msnmntr.c
@@ -257,7 +257,7 @@ MonitorCoAllocFlowContext(
 
    *flowContextOut = NULL;
 
-   flowContext = ExAllocatePoolWithTag(NonPagedPool,
+   flowContext = ExAllocatePoolZero(NonPagedPool,
                                        sizeof(FLOW_DATA),
                                        TAG_NAME_CALLOUT);
 
@@ -271,7 +271,7 @@ MonitorCoAllocFlowContext(
                  sizeof(FLOW_DATA));
 
 
-   flowContext->processPath = ExAllocatePoolWithTag(NonPagedPool,
+   flowContext->processPath = ExAllocatePoolZero(NonPagedPool,
                                                     processPathSize,
                                                     TAG_NAME_CALLOUT);
    if (!flowContext->processPath)

--- a/network/trans/msnmntr/sys/msnmntr.c
+++ b/network/trans/msnmntr/sys/msnmntr.c
@@ -258,8 +258,8 @@ MonitorCoAllocFlowContext(
    *flowContextOut = NULL;
 
    flowContext = ExAllocatePoolZero(NonPagedPool,
-                                       sizeof(FLOW_DATA),
-                                       TAG_NAME_CALLOUT);
+                                    sizeof(FLOW_DATA),
+                                    TAG_NAME_CALLOUT);
 
    if (!flowContext)
    {
@@ -272,8 +272,8 @@ MonitorCoAllocFlowContext(
 
 
    flowContext->processPath = ExAllocatePoolZero(NonPagedPool,
-                                                    processPathSize,
-                                                    TAG_NAME_CALLOUT);
+                                                 processPathSize,
+                                                 TAG_NAME_CALLOUT);
    if (!flowContext->processPath)
    {
       status = STATUS_NO_MEMORY;

--- a/network/trans/msnmntr/sys/notify.c
+++ b/network/trans/msnmntr/sys/notify.c
@@ -270,7 +270,7 @@ NTSTATUS MonitorNfNotifyMessage(
    if(streamLength == 0)
       return status;
 
-   stream =  ExAllocatePoolWithTag(NonPagedPool,
+   stream =  ExAllocatePoolZero(NonPagedPool,
                                    streamLength,
                                    TAG_NAME_NOTIFY);
    if (!stream)

--- a/network/trans/msnmntr/sys/notify.c
+++ b/network/trans/msnmntr/sys/notify.c
@@ -270,9 +270,9 @@ NTSTATUS MonitorNfNotifyMessage(
    if(streamLength == 0)
       return status;
 
-   stream =  ExAllocatePoolZero(NonPagedPool,
-                                   streamLength,
-                                   TAG_NAME_NOTIFY);
+   stream = ExAllocatePoolZero(NonPagedPool,
+                               streamLength,
+                               TAG_NAME_NOTIFY);
    if (!stream)
       return STATUS_INSUFFICIENT_RESOURCES;
 


### PR DESCRIPTION
Updated sample to remove deprecated API usage (ExAllocatePoolWithTag to ExAllocatePoolZero)