### PR TITLE
fix accessing nullPtr when calling IoCsqRemoveNextIrp if IRP list is …

### DIFF
--- a/general/cancel/sys/cancel.c
+++ b/general/cancel/sys/cancel.c
@@ -837,6 +837,8 @@ PIRP CsampPeekNextIrp(
     //
 
     if (Irp == NULL) {
+        if (IsListEmpty(listHead) == TRUE)
+            return NULL;
         nextEntry = listHead->Flink;
     } else {
         nextEntry = Irp->Tail.Overlay.ListEntry.Flink;


### PR DESCRIPTION
…empty