### PR TITLE
Improvements to WFP Inspect Sample

### DIFF
--- a/network/trans/inspect/inspect.sln
+++ b/network/trans/inspect/inspect.sln
@@ -1,28 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 12.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "inspect", "sys\inspect.vcxproj", "{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
-		Release|Win32 = Release|Win32
 		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Debug|Win32.ActiveCfg = Debug|Win32
-		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Debug|Win32.Build.0 = Debug|Win32
-		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Release|Win32.ActiveCfg = Release|Win32
-		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Release|Win32.Build.0 = Release|Win32
+		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Debug|Win32.ActiveCfg = Debug|x64
+		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Debug|Win32.Build.0 = Debug|x64
 		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Debug|x64.ActiveCfg = Debug|x64
 		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Debug|x64.Build.0 = Debug|x64
+		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Release|Win32.ActiveCfg = Release|Win32
+		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Release|Win32.Build.0 = Release|Win32
 		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Release|x64.ActiveCfg = Release|x64
 		{5CF7CFC1-02B4-4938-AC5F-47D743D82E8A}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F084D2B3-2035-4BCE-A4D1-FA6AE812D7A1}
 	EndGlobalSection
 EndGlobal

--- a/network/trans/inspect/sys/inspect.c
+++ b/network/trans/inspect/sys/inspect.c
@@ -1278,7 +1278,7 @@ TLInspectWorker(
                                 listEntry
                                 );
 
-            NT_ASSERT((packet->direction == FWP_DIRECTION_INBOUND) ||
+            NT_ASSERT((packet->direction != FWP_DIRECTION_INBOUND) ||
                       (packet->authConnectDecision == 0));
         
             if (packet->authConnectDecision == 0)

--- a/network/trans/inspect/sys/inspect.vcxproj
+++ b/network/trans/inspect/sys/inspect.vcxproj
@@ -23,14 +23,14 @@
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <KMDF_VERSION_MAJOR>1</KMDF_VERSION_MAJOR>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform>Desktop</Platform>
     <SampleGuid>{910EE323-2C33-42E0-B2DD-3C3BB1F4689E}</SampleGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -38,7 +38,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -46,7 +46,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -54,7 +54,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -75,7 +75,10 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
-  <ItemGroup Label="WrappedTaskItems" />
+  <ItemGroup Label="WrappedTaskItems">
+    <ClInclude Include="inspect.h" />
+    <ClInclude Include="utils.h" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>inspect</TargetName>
   </PropertyGroup>
@@ -170,7 +173,6 @@
     <ClCompile Include="utils.c" />
   </ItemGroup>
   <ItemGroup>
-    <Inf Exclude="@(Inf)" Include="*.inf" />
     <FilesToPackage Include="$(TargetPath)" Condition="'$(ConfigurationType)'=='Driver' or '$(ConfigurationType)'=='DynamicLibrary'" />
   </ItemGroup>
   <ItemGroup>
@@ -179,7 +181,7 @@
     <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
+    <Inf Include="inspect.inf" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/network/trans/inspect/sys/inspect.vcxproj.Filters
+++ b/network/trans/inspect/sys/inspect.vcxproj.Filters
@@ -29,4 +29,17 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="inspect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="inspect.inf">
+      <Filter>Driver Files</Filter>
+    </Inf>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes a `NT_ASSERT` to match what the comment above is saying, the previous version caused a system crash if the packet was not inbound and had a auth decision made already. 
The comment
`         // Skip pended connections in the list, for which the auth decision is already taken.`
`         // They should not be for inbound connections.`
to my understanding means inbound connections should be ignored and ignore connections for which the auth decision was already made. The latter is checked by:
` if (packet->authConnectDecision == 0)` 
which keeps `found` equal to `FALSE` triggering the packet and list entry to be set to `NULL` here:
`if (!found)
         {
            listEntry = NULL;
            packet = NULL;
         }`

Change also updates the .sln and .vxproj  files so the sample compiles on VS2019 without any changes - addressing #366 
