### PR TITLE
modify DelReg directive to refer correct section

### DIFF
--- a/network/trans/WFPSampler/sys/WFPSamplerCalloutDriver.InX
+++ b/network/trans/WFPSampler/sys/WFPSamplerCalloutDriver.InX
@@ -48,7 +48,7 @@
 
 [DefaultUninstall.nt$ARCH$]
    DelFiles = WFPSamplerCalloutDriver.DriverFiles
-   DelReg   = WFPCalloutClassReg
+   DelReg   = WFPCalloutsClassReg
 
 [DefaultUninstall.nt$ARCH$.Services]
    DelService = %WFPSamplerCalloutDriverServiceName%,0x200                                         ;/// SPSVCINST_STOPSERVICE


### PR DESCRIPTION
The DefaultUninstall section's DelReg directive was referring to a non-existent section (WFPCalloutClassReg) most likely due to typo. As a result a build error occurs.
Fixed the section name to an existing one (WFPCalloutsClassReg). Confirmed fix is effective by observing a successful build.