### PR TITLE
fix bug in PackReport

### DIFF
--- a/hid/hclient/report.c
+++ b/hid/hclient/report.c
@@ -513,7 +513,7 @@ Routine Description:
     ULONG       i;
     ULONG       CurrReportID;
     BOOLEAN     result = FALSE;
-
+    PHID_DATA   Head = Data;
     /*
     // All report buffers that are initially sent need to be zero'd out
     */
@@ -584,6 +584,7 @@ Routine Description:
     //    having been set.
     */
 
+    Data = Head;
     for (i = 0; i < DataLength; i++, Data++) 
     {
         if (CurrReportID == Data -> ReportID)


### PR DESCRIPTION
Data is pointer to array of HID_DATA structure.
Function advances pointer as it packs the report buffer.
At end of process in success condition, the function attempts to walk the array a second time and update the IsDataSet member for the HID_DATA elements that were packed.

What it's actually doing in the second pass is writing unexpected memory locations.
Fix is to store the head of the array and move back before walking again to set the bits.