### PR TITLE
CDFS: Fix memory disclosure in CdQueryFsVolumeInfo

### DIFF
--- a/filesys/cdfs/volinfo.c
+++ b/filesys/cdfs/volinfo.c
@@ -156,6 +156,8 @@ Return Value:
         //  and false if it couldn't wait for any I/O to complete.
         //
 
+        RtlZeroMemory(Irp->AssociatedIrp.SystemBuffer, Length);
+
         switch (IrpSp->Parameters.QueryVolume.FsInformationClass) {
 
         case FileFsSizeInformation:


### PR DESCRIPTION
The structure _FILE_FS_VOLUME_INFORMATION
```
kd> dt _FIlE_FS_VOLUME_INFORMATION
shell32!_FILE_FS_VOLUME_INFORMATION
   +0x000 VolumeCreationTime : _LARGE_INTEGER
   +0x008 VolumeSerialNumber : Uint4B
   +0x00c VolumeLabelLength : Uint4B
   +0x010 SupportsObjects  : UChar
   +0x012 VolumeLabel      : [1] Wchar
```
is added 1 padding byte after the field SupportsObjects so it will lead to memory disclosure although all fields are initialized.

This driver is used by ReactOS, https://github.com/reactos/reactos/pull/2975