### PR TITLE
[vhidmini] Delete unreferenced DEVICE_CONTEXT struct DefaultQueue member

### DIFF
--- a/hid/vhidmini2/driver/vhidmini.c
+++ b/hid/vhidmini2/driver/vhidmini.c
@@ -185,12 +185,6 @@ Return Value:
     hidAttributes->ProductID    = HIDMINI_PID;
     hidAttributes->VersionNumber = HIDMINI_VERSION;
 
-    status = QueueCreate(device,
-                         &deviceContext->DefaultQueue);
-    if( !NT_SUCCESS(status) ) {
-        return status;
-    }
-
     status = ManualQueueCreate(device,
                                &deviceContext->ManualQueue);
     if( !NT_SUCCESS(status) ) {

--- a/hid/vhidmini2/driver/vhidmini.h
+++ b/hid/vhidmini2/driver/vhidmini.h
@@ -37,7 +37,6 @@ EVT_WDF_TIMER                       EvtTimerFunc;
 typedef struct _DEVICE_CONTEXT
 {
     WDFDEVICE               Device;
-    WDFQUEUE                DefaultQueue;
     WDFQUEUE                ManualQueue;
     HID_DEVICE_ATTRIBUTES   HidDeviceAttributes;
     BYTE                    DeviceData;


### PR DESCRIPTION
This queue doesn't seem to be used for anything. Therefore, proposing to remove it to simplify the sample project.