### PR TITLE
DV-FailDriver-WDM: Add pnplockdown to INF and set file signing algorithm to sha256

### DIFF
--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
@@ -18,6 +18,7 @@ ClassGuid={4d36e97d-e325-11ce-bfc1-08002be10318}
 Provider="Sample Provider"
 DriverVer=12/12/2017,10.0.0.1
 CatalogFile=Defect_Toastmon.cat
+PnpLockdown=1
 
 [DestinationDirs]
 DefaultDestDir = 12

--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.vcxproj
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.vcxproj
@@ -99,6 +99,9 @@
       <ExceptionHandling>
       </ExceptionHandling>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -107,6 +110,9 @@
       <ExceptionHandling>
       </ExceptionHandling>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -115,6 +121,9 @@
       <ExceptionHandling>
       </ExceptionHandling>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -123,6 +132,9 @@
       <ExceptionHandling>
       </ExceptionHandling>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\defect_toastmon.c" />


### PR DESCRIPTION
- Set `PnpLockdown=1` in the INF.
- Set SHA256 as the file signing algorithm in the project file.