### PR TITLE
Buses samples should use ExAllocatePool2

### DIFF
--- a/general/echo/kmdf/driver/AutoSync/queue.c
+++ b/general/echo/kmdf/driver/AutoSync/queue.c
@@ -423,7 +423,7 @@ Return Value:
         queueContext->Length = 0L;
     }
 
-    queueContext->Buffer = ExAllocatePoolWithTag(NonPagedPoolNx, Length, 'sam1');
+    queueContext->Buffer = ExAllocatePool2(POOL_FLAG_NON_PAGED, Length, 'sam1');
     if( queueContext->Buffer == NULL ) {
         KdPrint(("EchoEvtIoWrite: Could not allocate %Iu byte buffer\n", Length));
         WdfRequestComplete(Request, STATUS_INSUFFICIENT_RESOURCES);

--- a/general/echo/kmdf/driver/DriverSync/queue.c
+++ b/general/echo/kmdf/driver/DriverSync/queue.c
@@ -649,7 +649,7 @@ Return Value:
         queueContext->Length = 0L;
     }
 
-    queueContext->Buffer = ExAllocatePoolWithTag(NonPagedPoolNx, Length, 'sam1');
+    queueContext->Buffer = ExAllocatePool2(POOL_FLAG_NON_PAGED, Length, 'sam1');
     if( queueContext->Buffer == NULL ) {
         KdPrint(("EchoEvtIoWrite: Could not allocate %Iu byte buffer\n",Length));
         WdfRequestComplete(Request, STATUS_INSUFFICIENT_RESOURCES);

--- a/general/ioctl/kmdf/sys/nonpnp.c
+++ b/general/ioctl/kmdf/sys/nonpnp.c
@@ -459,10 +459,10 @@ Return Value:
     //
     length = directory.Length + fileName->Length;
 
-    absFileName.Buffer = ExAllocatePoolWithTag(PagedPool, length, POOL_TAG);
+    absFileName.Buffer = ExAllocatePool2(POOL_FLAG_PAGED, length, POOL_TAG);
     if(absFileName.Buffer == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;
-        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "ExAllocatePoolWithTag failed");
+        TraceEvents(TRACE_LEVEL_ERROR, DBG_INIT, "ExAllocatePool2 failed");
         goto End;
     }
     absFileName.Length = 0;

--- a/general/toaster/toastDrv/kmdf/bus/dynamic/buspdo.c
+++ b/general/toaster/toastDrv/kmdf/bus/dynamic/buspdo.c
@@ -82,8 +82,8 @@ Return Value:
         return status;
     }
 
-    dst->HardwareIds = (PWCHAR) ExAllocatePoolWithTag(
-        NonPagedPoolNx,
+    dst->HardwareIds = (PWCHAR) ExAllocatePool2(
+        POOL_FLAG_NON_PAGED,
         safeMultResult,
         BUS_TAG);
 

--- a/general/toaster/toastDrv/kmdf/func/featured/wmi.c
+++ b/general/toaster/toastDrv/kmdf/func/featured/wmi.c
@@ -446,11 +446,9 @@ ToasterFireArrivalEvent(
     //
     // Allocate memory for the WNODE from NonPagedPoolNx
     //
-    wnode = ExAllocatePoolWithTag(NonPagedPoolNx, size, TOASTER_POOL_TAG);
+    wnode = ExAllocatePool2(POOL_FLAG_NON_PAGED, size, TOASTER_POOL_TAG);
 
     if (NULL != wnode) {
-        RtlZeroMemory(wnode, size);
-
         wnode->WnodeHeader.BufferSize = size;
         wnode->WnodeHeader.ProviderId =
                             IoWMIDeviceObjectToProviderId(

--- a/serial/serial/ioctl.c
+++ b/serial/serial/ioctl.c
@@ -1297,8 +1297,8 @@ Return Value:
             }
 
             reqContext->Type3InputBuffer =
-                    ExAllocatePoolWithQuotaTag(
-                        NonPagedPoolNx | POOL_QUOTA_FAIL_INSTEAD_OF_RAISE,
+                    ExAllocatePool2(
+                        POOL_FLAG_NON_PAGED | POOL_FLAG_USE_QUOTA,
                         Rs->InSize,
                         POOL_TAG
                         );

--- a/serial/serial/openclos.c
+++ b/serial/serial/openclos.c
@@ -148,8 +148,8 @@ SerialDeviceFileCreateWorker (
         case MmLargeSystem: {
 
             extension->BufferSize = 4096;
-            extension->InterruptReadBuffer = ExAllocatePoolWithTag(
-                                                 NonPagedPoolNx,
+            extension->InterruptReadBuffer = ExAllocatePool2(
+                                                 POOL_FLAG_NON_PAGED,
                                                  extension->BufferSize,
                                                  POOL_TAG
                                                  );
@@ -163,8 +163,8 @@ SerialDeviceFileCreateWorker (
         case MmMediumSystem: {
 
             extension->BufferSize = 1024;
-            extension->InterruptReadBuffer = ExAllocatePoolWithTag(
-                                                 NonPagedPoolNx,
+            extension->InterruptReadBuffer = ExAllocatePool2(
+                                                 POOL_FLAG_NON_PAGED,
                                                  extension->BufferSize,
                                                  POOL_TAG
                                                  );
@@ -178,8 +178,8 @@ SerialDeviceFileCreateWorker (
         case MmSmallSystem: {
 
             extension->BufferSize = 128;
-            extension->InterruptReadBuffer = ExAllocatePoolWithTag(
-                                                 NonPagedPoolNx,
+            extension->InterruptReadBuffer = ExAllocatePool2(
+                                                 POOL_FLAG_NON_PAGED,
                                                  extension->BufferSize,
                                                  POOL_TAG
                                                  );

--- a/usb/UcmCxUcsi/Acpi.cpp
+++ b/usb/UcmCxUcsi/Acpi.cpp
@@ -554,9 +554,9 @@ Acpi_EvaluateUcsiDsm (
         FIELD_OFFSET(ACPI_EVAL_OUTPUT_BUFFER, Argument) +
         outputArgumentBufferSize;
 
-    outputBuffer = (PACPI_EVAL_OUTPUT_BUFFER) ExAllocatePoolWithTag(NonPagedPoolNx,
-                                                                    outputBufferSize,
-                                                                    TAG_UCSI);
+    outputBuffer = (PACPI_EVAL_OUTPUT_BUFFER) ExAllocatePool2(POOL_FLAG_NON_PAGED,
+                                                              outputBufferSize,
+                                                              TAG_UCSI);
 
     if (outputBuffer == nullptr)
     {
@@ -564,8 +564,6 @@ Acpi_EvaluateUcsiDsm (
         TRACE_ERROR(TRACE_FLAG_ACPI, "[Device: 0x%p] ExAllocatePoolWithTag failed for %Iu bytes", device, outputBufferSize);
         goto Exit;
     }
-
-    RtlZeroMemory(outputBuffer, outputBufferSize);
 
     WDF_MEMORY_DESCRIPTOR_INIT_HANDLE(&inputMemDesc, inputMemory, NULL);
     WDF_MEMORY_DESCRIPTOR_INIT_BUFFER(&outputMemDesc, outputBuffer, (ULONG) outputBufferSize);

--- a/usb/ufxclientsample/device.c
+++ b/usb/ufxclientsample/device.c
@@ -535,8 +535,8 @@ Arguments:
     DeviceContext = UfxDeviceGetContext(ControllerContext->UfxDevice);
 
 #pragma prefast(suppress:6014, "Memory allocation is expected")
-    HardwareFailureContext = ExAllocatePoolWithTag(
-                                 NonPagedPoolNx,
+    HardwareFailureContext = ExAllocatePool2(
+                                 POOL_FLAG_NON_PAGED,
                                  sizeof(HARDWARE_FAILURE_CONTEXT),
                                  UFX_CLIENT_TAG);
 

--- a/usb/usbsamp/sys/private.h
+++ b/usb/usbsamp/sys/private.h
@@ -53,9 +53,8 @@ Environment:
 #define DISPATCH_LATENCY_IN_MS 10
 
 
-#undef ExAllocatePool
-#define ExAllocatePool(type, size) \
-    ExAllocatePoolWithTag(type, size, POOL_TAG);
+#define MyExAllocatePool2(flags, size) \
+    ExAllocatePool2(flags, size, POOL_TAG);
 
 #if DBG
 

--- a/usb/usbsamp/sys/private.h
+++ b/usb/usbsamp/sys/private.h
@@ -52,10 +52,6 @@ Environment:
 
 #define DISPATCH_LATENCY_IN_MS 10
 
-
-#define MyExAllocatePool2(flags, size) \
-    ExAllocatePool2(flags, size, POOL_TAG);
-
 #if DBG
 
 #define UsbSamp_DbgPrint(level, _x_) \

--- a/usb/usbsamp/sys/stream.c
+++ b/usb/usbsamp/sys/stream.c
@@ -199,8 +199,8 @@ Return Value:
 
     pStreamInfo->NumberOfStreams = supportedStreams;
 
-    pStreamInfo->StreamList = ExAllocatePoolWithTag(
-                                    NonPagedPoolNx,
+    pStreamInfo->StreamList = ExAllocatePool2(
+                                    POOL_FLAG_NON_PAGED,
                                     supportedStreams * sizeof(USBD_STREAM_INFORMATION),
                                     POOL_TAG);
 


### PR DESCRIPTION
`ExAllocatePoolWithTag` has being deprecated since Windows 2004/20H1 due to security issues (does not zero-initialize memory). 
 [ExAllocatePool2](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2) is now the preferred way to allocate pool memory.

Built all affected projects locally with latest public WDK (WDK for Windows 10, version 2004)