### PR TITLE
Remove deprecated API usage in DV-FailDriver-WDM sample.

### DIFF
--- a/tools/dv/samples/DV-FailDriver-WDM/defect_toastmon.c
+++ b/tools/dv/samples/DV-FailDriver-WDM/defect_toastmon.c
@@ -828,7 +828,7 @@ Return Value:
         // Allocate memory for the deviceinfo
         //
 
-        list = ExAllocatePoolWithTag(PagedPool,sizeof(DEVICE_INFO),DRIVER_TAG);
+        list = ExAllocatePool2(POOL_FLAG_PAGED, sizeof(DEVICE_INFO), DRIVER_TAG);
         if (list == NULL)
         {
             goto Error;
@@ -841,10 +841,10 @@ Return Value:
         list->SymbolicLink.MaximumLength = symbolicLinkName->Length +
                                           sizeof(UNICODE_NULL);
         list->SymbolicLink.Length = symbolicLinkName->Length;
-        list->SymbolicLink.Buffer = ExAllocatePoolWithTag (
-                                       PagedPool,
-                                       list->SymbolicLink.MaximumLength,
-                                       DRIVER_TAG);
+        list->SymbolicLink.Buffer = ExAllocatePool2(
+                                        POOL_FLAG_PAGED,
+                                        list->SymbolicLink.MaximumLength,
+                                        DRIVER_TAG);
         if (list->SymbolicLink.Buffer == NULL)
         {
             goto Error;

--- a/tools/dv/samples/DV-FailDriver-WDM/wmi.c
+++ b/tools/dv/samples/DV-FailDriver-WDM/wmi.c
@@ -191,8 +191,8 @@ Return Value:
         }
     }
 
-    valueInfo = ExAllocatePoolWithTag (NonPagedPool, resultLength,
-                                                DRIVER_TAG);
+    valueInfo = ExAllocatePool2(POOL_FLAG_NON_PAGED, resultLength,
+                                    DRIVER_TAG);
     if (NULL == valueInfo) {
         status = STATUS_INSUFFICIENT_RESOURCES;
         goto Error;


### PR DESCRIPTION
Update DV-FailDriver-WDM sample to use ExAllocatePool2 per new guidance.