### PR TITLE
Changed ExAllocatePool to ExAllocatePool2 with tag

### DIFF
--- a/bluetooth/serialhcibus/Io.h
+++ b/bluetooth/serialhcibus/Io.h
@@ -50,6 +50,8 @@ Revision History:
 
 #define BUFFER_AND_SIZE_ADJUSTED(Buffer, Size, SegmentCount, Increment) {Buffer += Increment; Size -= Increment; SegmentCount += Increment;}
 
+#define POOLTAG_BTHSERIALHCIBUSSAMPLE 'htbw'
+
 #include <PSHPACK1.H>
 
 //

--- a/bluetooth/serialhcibus/io.c
+++ b/bluetooth/serialhcibus/io.c
@@ -1178,7 +1178,7 @@ HLP_CreatePacketEntry(
 {
     PHCI_PACKET_ENTRY  PacketEntry = NULL;
 
-    PacketEntry = (PHCI_PACKET_ENTRY)ExAllocatePool(NonPagedPoolNx, sizeof(HCI_PACKET_ENTRY) + _PacketLength);
+    PacketEntry = (PHCI_PACKET_ENTRY)ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(HCI_PACKET_ENTRY) + _PacketLength, POOLTAG_BTHSERIALHCIBUSSAMPLE);
     if (PacketEntry != NULL) {
         InitializeListHead(&PacketEntry->DataEntry);
         RtlCopyMemory(PacketEntry->Packet, _Packet, _PacketLength);


### PR DESCRIPTION
### Why this change is needed?

Due to the `ExAllocatePool` function being deprecated, we needed to update the API call to the ExAllocatePool2 function. The reason behind this change is that `ExAllocatePool` allocates memory that is uninitialized, users need to zero the memory before making it visible to users (Avoid leaking kernel-mode contents). In comparison, the memory that `ExAllocatePool2` allocates is already zero initialized; the security risk of disclosing information is not present with this function call.

### How was this change implemented?

The change was implemented by changing `ExAllocatePool` to a `ExAllocatePool2` function call. This was done with the help of the following APIs: [`ExAllocatePool`](`https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool`) and [`ExAllocatePool2`](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2)

### How was this tested?

The driver was built using Visual Studio & WDK.

