### PR TITLE
Delete sub layer in case of failure

### DIFF
--- a/network/trans/inspect/sys/TL_drv.c
+++ b/network/trans/inspect/sys/TL_drv.c
@@ -507,6 +507,7 @@ TLInspectRegisterCallouts(
 
    BOOLEAN engineOpened = FALSE;
    BOOLEAN inTransaction = FALSE;
+   BOOLEAN sublayerCreated = FALSE;
 
    FWPM_SESSION session = {0};
 
@@ -549,6 +550,8 @@ TLInspectRegisterCallouts(
    {
       goto Exit;
    }
+   
+   sublayerCreated = TRUE;
 
    if (configInspectRemoteAddrV4 != NULL)
    {
@@ -655,6 +658,10 @@ Exit:
 
    if (!NT_SUCCESS(status))
    {
+	  if (sublayerCreated)
+	  {
+		 FwpmSubLayerDeleteByKey(gEngineHandle, &TL_INSPECT_SUBLAYER);  
+	  }
       if (inTransaction)
       {
          FwpmTransactionAbort(gEngineHandle);


### PR DESCRIPTION
Delete the created sub-layer in case of failure instead of relying on `FwpmTransactionAbort` in order to prevent potentially leaked sub-layer. 