### PR TITLE
[network\trans] ExAllocatePoolWithTag changing to ExAllocatePoolZero

### DIFF
--- a/network/trans/ddproxy/sys/DD_drv.c
+++ b/network/trans/ddproxy/sys/DD_drv.c
@@ -32,6 +32,7 @@ Environment:
 
 --*/
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <ntddk.h>
 #include <wdf.h>
 

--- a/network/trans/ddproxy/sys/DD_proxy.c
+++ b/network/trans/ddproxy/sys/DD_proxy.c
@@ -114,8 +114,6 @@ DDProxyFlowEstablishedClassify(
       goto Exit;
    }
 
-   RtlZeroMemory(flowContextLocal, sizeof(DD_PROXY_FLOW_CONTEXT));
-
    flowContextLocal->refCount = 1;
    flowContextLocal->flowType = (DD_PROXY_FLOW_TYPE)(filter->context);
    flowContextLocal->addressFamily = 
@@ -346,8 +344,6 @@ DDProxyClassify(
       classifyOut->rights &= ~FWPS_RIGHT_ACTION_WRITE;
       goto Exit;
    }
-
-   RtlZeroMemory(packet, sizeof(DD_PROXY_PENDED_PACKET));
 
    NT_ASSERT(flowContextLocal != NULL);
 

--- a/network/trans/ddproxy/sys/DD_proxy.c
+++ b/network/trans/ddproxy/sys/DD_proxy.c
@@ -102,7 +102,7 @@ DDProxyFlowEstablishedClassify(
 #endif /// (NTDDI_VERSION >= NTDDI_WIN7)
    UNREFERENCED_PARAMETER(flowContext);
 
-   flowContextLocal = ExAllocatePoolWithTag(
+   flowContextLocal = ExAllocatePoolZero(
                         NonPagedPool,
                         sizeof(DD_PROXY_FLOW_CONTEXT),
                         DD_PROXY_FLOW_CONTEXT_POOL_TAG
@@ -334,7 +334,7 @@ DDProxyClassify(
       goto Exit;
    }
 
-   packet = ExAllocatePoolWithTag(
+   packet = ExAllocatePoolZero(
                      NonPagedPool,
                      sizeof(DD_PROXY_PENDED_PACKET),
                      DD_PROXY_PENDED_PACKET_POOL_TAG
@@ -413,7 +413,7 @@ DDProxyClassify(
       {
          NT_ASSERT(inMetaValues->controlDataLength > 0);
 
-         packet->controlData = ExAllocatePoolWithTag(
+         packet->controlData = ExAllocatePoolZero(
                                  NonPagedPool,
                                  inMetaValues->controlDataLength,
                                  DD_PROXY_CONTROL_DATA_POOL_TAG

--- a/network/trans/ddproxy/sys/DD_proxy.c
+++ b/network/trans/ddproxy/sys/DD_proxy.c
@@ -22,6 +22,7 @@ Environment:
 
 --*/
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <ntddk.h>
 
 #pragma warning(push)

--- a/network/trans/ddproxy/sys/ddproxy.inf
+++ b/network/trans/ddproxy/sys/ddproxy.inf
@@ -12,6 +12,7 @@
     Provider    = %ProviderString%
     CatalogFile = DDProxy.cat
     DriverVer   = 11/24/2014,14.24.55.836
+    PnpLockdown = 1
 
 [SourceDisksNames]
    1 = %DDProxyDisk%,,,""

--- a/network/trans/ddproxy/sys/ddproxy.vcxproj
+++ b/network/trans/ddproxy/sys/ddproxy.vcxproj
@@ -44,9 +44,10 @@
     <ConfigurationType>Driver</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetVersion>Windows10</TargetVersion>
+    <TargetVersion>
+    </TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>

--- a/network/trans/ddproxy/sys/ddproxy.vcxproj
+++ b/network/trans/ddproxy/sys/ddproxy.vcxproj
@@ -30,7 +30,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -38,7 +38,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -54,7 +54,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>

--- a/network/trans/ddproxy/sys/ddproxy.vcxproj
+++ b/network/trans/ddproxy/sys/ddproxy.vcxproj
@@ -44,8 +44,7 @@
     <ConfigurationType>Driver</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetVersion>
-    </TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>

--- a/network/trans/ddproxy/sys/ddproxy.vcxproj.Filters
+++ b/network/trans/ddproxy/sys/ddproxy.vcxproj.Filters
@@ -26,4 +26,14 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="*.inf">
+      <Filter>Driver Files</Filter>
+    </Inf>
+  </ItemGroup>
 </Project>

--- a/network/trans/inspect/sys/TL_drv.c
+++ b/network/trans/inspect/sys/TL_drv.c
@@ -31,6 +31,7 @@ Environment:
 
 --*/
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <ntddk.h>
 #include <wdf.h>
 

--- a/network/trans/inspect/sys/inspect.c
+++ b/network/trans/inspect/sys/inspect.c
@@ -22,7 +22,7 @@ Environment:
 
 --*/
 
-
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <ntddk.h>
 
 #pragma warning(push)

--- a/network/trans/inspect/sys/inspect.inf
+++ b/network/trans/inspect/sys/inspect.inf
@@ -12,6 +12,7 @@
     Provider    = %ProviderString%
     CatalogFile = Inspect.cat
     DriverVer   = 11/24/2014,14.24.55.836
+    PnpLockdown = 1
 
 [SourceDisksNames]
    1 = %InspectDisk%,,,""

--- a/network/trans/inspect/sys/inspect.inf
+++ b/network/trans/inspect/sys/inspect.inf
@@ -24,17 +24,19 @@
     DefaultDestDir      = 12                                               ; %WinDir%\System32\Drivers
     Inspect.DriverFiles = 12                                               ; %WinDir%\System32\Drivers
 
-[DefaultInstall]
+[DefaultInstall.NT$ARCH$]
     OptionDesc = %InspectServiceDesc%
     CopyFiles  = Inspect.DriverFiles
 
-[DefaultInstall.Services]
+[DefaultInstall.NT$ARCH$.Services]
     AddService = %InspectServiceName%,,Inspect.Service
 
-[DefaultUninstall]
+[DefaultUninstall.NT$ARCH$]
+    LegacyUninstall = 1
     DelFiles = Inspect.DriverFiles
 
-[DefaultUninstall.Services]
+[DefaultUninstall.NT$ARCH$.Services]
+    LegacyUninstall = 1
     DelService = %InspectServiceName%,0x200                                ; SPSVCINST_STOPSERVICE
     DelReg     = Inspect.DelRegistry
 

--- a/network/trans/inspect/sys/utils.c
+++ b/network/trans/inspect/sys/utils.c
@@ -291,7 +291,7 @@ AllocateAndInitializePendedPacket(
 {
    TL_INSPECT_PENDED_PACKET* pendedPacket;
 
-   pendedPacket = ExAllocatePoolWithTag(
+   pendedPacket = ExAllocatePoolZero(
                         NonPagedPool,
                         sizeof(TL_INSPECT_PENDED_PACKET),
                         TL_INSPECT_PENDED_PACKET_POOL_TAG
@@ -346,7 +346,7 @@ AllocateAndInitializePendedPacket(
       {
          NT_ASSERT(inMetaValues->controlDataLength > 0);
 
-         pendedPacket->controlData = ExAllocatePoolWithTag(
+         pendedPacket->controlData = ExAllocatePoolZero(
                                        NonPagedPool,
                                        inMetaValues->controlDataLength,
                                        TL_INSPECT_CONTROL_DATA_POOL_TAG

--- a/network/trans/inspect/sys/utils.c
+++ b/network/trans/inspect/sys/utils.c
@@ -13,7 +13,7 @@ Environment:
 
 --*/
 
-
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <ntddk.h>
 #include <wdf.h>
 

--- a/network/trans/inspect/sys/utils.c
+++ b/network/trans/inspect/sys/utils.c
@@ -302,8 +302,6 @@ AllocateAndInitializePendedPacket(
       return NULL;
    }
 
-   RtlZeroMemory(pendedPacket, sizeof(TL_INSPECT_PENDED_PACKET));
-
    pendedPacket->type = packetType;
    pendedPacket->direction = packetDirection;
 

--- a/network/trans/stmedit/sys/InlineEdit.c
+++ b/network/trans/stmedit/sys/InlineEdit.c
@@ -12,6 +12,7 @@ Environment:
     Kernel mode
 --*/
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include "Trace.h"
 #include "StreamEdit.h"
 #include "InlineEdit.tmh"

--- a/network/trans/stmedit/sys/InlineEdit.c
+++ b/network/trans/stmedit/sys/InlineEdit.c
@@ -54,7 +54,7 @@ InlineEditFlushData(
         if (DataLength == 0)
             break;
 
-        Buffer = ExAllocatePoolWithTag(NonPagedPool, DataLength, STMEDIT_TAG_MDL_DATA);
+        Buffer = ExAllocatePoolZero(NonPagedPool, DataLength, STMEDIT_TAG_MDL_DATA);
         if (Buffer == NULL)
 		{
             Status = STATUS_INSUFFICIENT_RESOURCES;

--- a/network/trans/stmedit/sys/LwQueue.c
+++ b/network/trans/stmedit/sys/LwQueue.c
@@ -36,7 +36,7 @@ LwInitializeQueue(
     KeInitializeSpinLock(&Queue->Lock);
 
     Queue->WorkItem =
-        ExAllocatePoolWithTag(
+        ExAllocatePoolZero(
         NonPagedPool, IoSizeofWorkItem(), STMEDIT_TAG_LQWI);
 
     if (Queue->WorkItem == NULL) 

--- a/network/trans/stmedit/sys/LwQueue.c
+++ b/network/trans/stmedit/sys/LwQueue.c
@@ -10,6 +10,7 @@ Environment:
 
 --*/
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include "LwQueue.h"
 
 IO_WORKITEM_ROUTINE     LwWorker;

--- a/network/trans/stmedit/sys/LwQueue.h
+++ b/network/trans/stmedit/sys/LwQueue.h
@@ -1,6 +1,7 @@
 #ifndef _LWQUEUE_H
 #define _LWQUEUE_H
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <wdm.h>
 
 #define STMEDIT_TAG_LQWI 'wLeS'   // Light Weight Queue Work Items.

--- a/network/trans/stmedit/sys/OobEdit.c
+++ b/network/trans/stmedit/sys/OobEdit.c
@@ -13,6 +13,7 @@ Environment:
 
 --*/
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include "Trace.h"
 #include "StreamEdit.h"
 #include "OobEdit.tmh"

--- a/network/trans/stmedit/sys/OobEdit.c
+++ b/network/trans/stmedit/sys/OobEdit.c
@@ -378,7 +378,7 @@ StreamOobReinjectData(
 
     do
     {
-        DataCopy = ExAllocatePoolWithTag(
+        DataCopy = ExAllocatePoolZero(
                         NonPagedPool,
                         Length,
                         STMEDIT_TAG_MDL_DATA

--- a/network/trans/stmedit/sys/StreamEdit.c
+++ b/network/trans/stmedit/sys/StreamEdit.c
@@ -464,7 +464,7 @@ StreamEditFlowEstablishedClassify(
 
     do
     {
-        StreamFlowContext = ExAllocatePoolWithTag(NonPagedPoolNx,
+        StreamFlowContext = ExAllocatePoolZero(NonPagedPoolNx,
                                 sizeof(STREAM_FLOW_CONTEXT),
                                 STMEDIT_TAG_FLOWCTX);
 
@@ -1557,7 +1557,7 @@ _In_ SIZE_T BytesToCopy
     {
         size_t NewBufferSize = BytesToCopy + ExistingDataLength;
 
-        PVOID  NewBuffer = ExAllocatePoolWithTag(
+        PVOID  NewBuffer = ExAllocatePoolZero(
                                     NonPagedPool,
                                     (NewBufferSize + (NewBufferSize >> 1) ), // 1.5 times the needed size.
                                     STMEDIT_TAG_FLAT_BUFFER);
@@ -1567,7 +1567,7 @@ _In_ SIZE_T BytesToCopy
 
             // We are not able to allocate a much bigger buffer ... lets try an exact fit.
             //
-            NewBuffer = ExAllocatePoolWithTag(NonPagedPool, NewBufferSize, STMEDIT_TAG_FLAT_BUFFER);
+            NewBuffer = ExAllocatePoolZero(NonPagedPool, NewBufferSize, STMEDIT_TAG_FLAT_BUFFER);
         }
 
         if (NewBuffer != NULL) 

--- a/network/trans/stmedit/sys/StreamEdit.c
+++ b/network/trans/stmedit/sys/StreamEdit.c
@@ -477,7 +477,6 @@ StreamEditFlowEstablishedClassify(
 
         // Initialize the flow-context
         //
-        RtlZeroMemory(StreamFlowContext, sizeof(STREAM_FLOW_CONTEXT));
 
         StreamFlowContext->IpProto = InFixedValues->incomingValue[ipProtIndex].value.uint16;
         StreamFlowContext->bFlowActive = TRUE;
@@ -1371,6 +1370,10 @@ DriverEntry(
    DoTraceLevelMessage(TRACE_LEVEL_INFORMATION, CO_ENTER_EXIT,"--> %!FUNC!: DrvObj %p, Regpath %wZ",  DriverObject, RegistryPath);
 
    do {
+
+       // Request NX Non-Paged Pool when available
+       ExInitializeDriverRuntime(DrvRtPoolNxOptIn);
+
         //
         // Initialize globals and Configuration structures.
         //

--- a/network/trans/stmedit/sys/StreamEdit.h
+++ b/network/trans/stmedit/sys/StreamEdit.h
@@ -16,6 +16,7 @@ Environment:
 #ifndef _STREAM_EDIT_H
 #define _STREAM_EDIT_H
 
+#define POOL_ZERO_DOWN_LEVEL_SUPPORT
 #include <ntifs.h>
 #include <wdf.h>
 

--- a/network/trans/stmedit/sys/stmedit.inf
+++ b/network/trans/stmedit/sys/stmedit.inf
@@ -12,6 +12,7 @@
     Provider    = %Contoso%
     CatalogFile = StmEdit.cat
     DriverVer   = 01/01/2015,1.0.09.15
+    PnpLockdown = 1
 
 [SourceDisksNames]
    1 = %StmEditDisk%,,,""

--- a/network/trans/stmedit/sys/stmedit.inf
+++ b/network/trans/stmedit/sys/stmedit.inf
@@ -24,17 +24,20 @@
     DefaultDestDir      = 12                              ; %WinDir%\System32\Drivers
     StmEdit.DriverFiles = 12                              ; %WinDir%\System32\Drivers
 
-[DefaultInstall]
+[DefaultInstall.NTamd64]
     OptionDesc = %StmEditServiceDesc%
     CopyFiles  = StmEdit.DriverFiles
 
-[DefaultInstall.Services]
+
+[DefaultInstall.NTamd64.Services]
     AddService = %StmEditServiceName%,,StmEdit.Service
 
-[DefaultUninstall]
+[DefaultUninstall.NTamd64]
+    LegacyUninstall=1
     DelFiles = StmEdit.DriverFiles
 
-[DefaultUninstall.Services]
+[DefaultUninstall.NTamd64.Services]
+    LegacyUninstall=1
     DelService = %StmEditServiceName%,0x200               ; SPSVCINST_STOPSERVICE
     DelReg     = StmEdit.DelRegistry
 

--- a/network/trans/stmedit/sys/stmedit.inf
+++ b/network/trans/stmedit/sys/stmedit.inf
@@ -24,19 +24,19 @@
     DefaultDestDir      = 12                              ; %WinDir%\System32\Drivers
     StmEdit.DriverFiles = 12                              ; %WinDir%\System32\Drivers
 
-[DefaultInstall.NTamd64]
+[DefaultInstall.NT$ARCH$]
     OptionDesc = %StmEditServiceDesc%
     CopyFiles  = StmEdit.DriverFiles
 
 
-[DefaultInstall.NTamd64.Services]
+[DefaultInstall.NT$ARCH$.Services]
     AddService = %StmEditServiceName%,,StmEdit.Service
 
-[DefaultUninstall.NTamd64]
+[DefaultUninstall.NT$ARCH$]
     LegacyUninstall=1
     DelFiles = StmEdit.DriverFiles
 
-[DefaultUninstall.NTamd64.Services]
+[DefaultUninstall.NT$ARCH$.Services]
     LegacyUninstall=1
     DelService = %StmEditServiceName%,0x200               ; SPSVCINST_STOPSERVICE
     DelReg     = StmEdit.DelRegistry

--- a/network/trans/stmedit/sys/stmedit.vcxproj
+++ b/network/trans/stmedit/sys/stmedit.vcxproj
@@ -36,11 +36,9 @@
     <ConfigurationType>Driver</ConfigurationType>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TargetVersion>
-    </TargetVersion>
+    <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>
-    </DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -49,7 +47,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
@@ -57,7 +55,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>

--- a/network/trans/stmedit/sys/stmedit.vcxproj
+++ b/network/trans/stmedit/sys/stmedit.vcxproj
@@ -30,7 +30,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <DriverType>KMDF</DriverType>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>

--- a/network/trans/stmedit/sys/stmedit.vcxproj.Filters
+++ b/network/trans/stmedit/sys/stmedit.vcxproj.Filters
@@ -43,11 +43,15 @@
     </ClInclude>
     <ClInclude Include="StreamEdit.h" />
     <ClInclude Include="Trace.h" />
-    <ClInclude Include="LwQueue.h">
+    <ClInclude Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="StreamEdit.h" />
-    <ClInclude Include="Trace.h" />
+    <ClInclude Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Inf Include="*.inf">


### PR DESCRIPTION
Per new security requirements the ExAllocatePoolWithTag are no longer secure using ExAllocatePoolZero instead of ExAllocatePool2 because these samples are downlevel drivers. Compiled with Visual Studio 2019. 

Also adds PnpLockdown = 1 to driver Inf files to resolve a compiler warning