### PR TITLE
Update driver.c to no longer use ExAllocatePool

### DIFF
--- a/network/modem/fakemodem/driver.c
+++ b/network/modem/fakemodem/driver.c
@@ -400,7 +400,6 @@ FmCreateDosDevicesSymbolicLink(
         status = STATUS_INSUFFICIENT_RESOURCES;
         goto Error;
     }
-    RtlZeroMemory(symbolicLink.Buffer, symbolicLink.MaximumLength);
     RtlAppendUnicodeToString(&symbolicLink, OBJECT_DIRECTORY);
     RtlAppendUnicodeStringToString(&symbolicLink, &comPort);
     //

--- a/network/modem/fakemodem/driver.c
+++ b/network/modem/fakemodem/driver.c
@@ -392,7 +392,7 @@ FmCreateDosDevicesSymbolicLink(
     symbolicLink.Length=0;
     symbolicLink.MaximumLength = sizeof(OBJECT_DIRECTORY) + comPort.MaximumLength;
 
-    symbolicLink.Buffer = ExAllocatePoolWithTag(PagedPool,
+    symbolicLink.Buffer = ExAllocatePool2(POOL_FLAG_PAGED,
                                                 symbolicLink.MaximumLength + sizeof(WCHAR),
                                                 'wkaF');
 


### PR DESCRIPTION
ref : MSFT 38345678: Update GitHub fakemodem sample to no longer use ExAllocatePool,