### PR TITLE
bug fix: updating UINT8 to UINT32 to correct wrong type comparison

### DIFF
--- a/network/trans/WFPSampler/syslib/HelperFunctions_Headers.cpp
+++ b/network/trans/WFPSampler/syslib/HelperFunctions_Headers.cpp
@@ -1555,7 +1555,7 @@ VOID KrnlHlprIPHeaderCalculateV4Checksum(_Inout_ NET_BUFFER_LIST* pNetBufferList
 
       pIPv4Header->checksum = 0;
 
-      for(UINT8 i = 0;
+      for(UINT32 i = 0;
           i < words;
           i++)
       {


### PR DESCRIPTION
Updating to repair a "Comparison with Wider Type" bug.