### PR TITLE
Storage/Disk ExAllocatePool->ExAllocatePool2

### DIFF
--- a/storage/class/disk/src/disk.c
+++ b/storage/class/disk/src/disk.c
@@ -1288,7 +1288,7 @@ Return Value:
             srbSize = sizeof(SCSI_REQUEST_BLOCK);
         }
 
-        srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+        srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                     srbSize,
                                     DISK_TAG_SRB);
         if (srb == NULL) {
@@ -1303,7 +1303,6 @@ Return Value:
             return(STATUS_INSUFFICIENT_RESOURCES);
         }
 
-        RtlZeroMemory(srb, srbSize);
         if (fdoExtension->AdapterDescriptor->SrbType == SRB_TYPE_STORAGE_REQUEST_BLOCK) {
 
             srbEx = (PSTORAGE_REQUEST_BLOCK)srb;
@@ -1849,15 +1848,13 @@ Return Value:
     // Allocate buffer for mode select header, block descriptor, and mode page.
     //
 
-    buffer = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    buffer = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                    length2,
                                    DISK_TAG_MODE_DATA);
 
     if (buffer == NULL) {
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(buffer, length2);
 
     //
     // Set length in header to size of mode page.
@@ -2719,7 +2716,7 @@ Return Value:
     // Allocate Srb from nonpaged pool.
     //
 
-    context = ExAllocatePoolWithTag(NonPagedPoolNx,
+    context = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                     sizeof(COMPLETION_CONTEXT),
                                     DISK_TAG_CCONTEXT);
 
@@ -2737,12 +2734,6 @@ Return Value:
 
     if (fdoExtension->AdapterDescriptor->SrbType == SRB_TYPE_STORAGE_REQUEST_BLOCK) {
         srbEx = &context->Srb.SrbEx;
-
-        //
-        // Zero out srb
-        //
-
-        RtlZeroMemory(srbEx, sizeof(context->Srb.SrbExBuffer));
 
         //
         // Set up STORAGE_REQUEST_BLOCK fields
@@ -2765,12 +2756,6 @@ Return Value:
         storAddrBtl8->AddressLength = STOR_ADDR_BTL8_ADDRESS_LENGTH;
 
     } else {
-
-        //
-        // Zero out srb.
-        //
-
-        RtlZeroMemory(srb, SCSI_REQUEST_BLOCK_SIZE);
 
         //
         // Write length to SRB.
@@ -2891,7 +2876,7 @@ DiskGetInfoExceptionInformation(
     // ReturnPageData is allocated by the caller
     //
 
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                          MODE_DATA_SIZE,
                                          DISK_TAG_INFO_EXCEPTION);
 
@@ -2901,8 +2886,6 @@ DiskGetInfoExceptionInformation(
                        "data buffer\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(modeData, MODE_DATA_SIZE);
 
     length = ClassModeSense(FdoExtension->DeviceObject,
                             (PCHAR) modeData,
@@ -3031,7 +3014,7 @@ Return Value:
 
 
 
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                      MODE_DATA_SIZE,
                                      DISK_TAG_DISABLE_CACHE);
 
@@ -3041,8 +3024,6 @@ Return Value:
                        "data buffer\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(modeData, MODE_DATA_SIZE);
 
     length = ClassModeSense(FdoExtension->DeviceObject,
                             (PCHAR) modeData,
@@ -3175,7 +3156,7 @@ Return Value:
 
     PAGED_CODE();
 
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                      MODE_DATA_SIZE,
                                      DISK_TAG_DISABLE_CACHE);
 
@@ -3185,8 +3166,6 @@ Return Value:
                        "data buffer\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(modeData, MODE_DATA_SIZE);
 
     length = ClassModeSense(FdoExtension->DeviceObject,
                             (PCHAR) modeData,
@@ -4041,7 +4020,7 @@ Return Value:
         srbSize = SCSI_REQUEST_BLOCK_SIZE;
     }
 
-    srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 srbSize,
                                 DISK_TAG_SRB);
 
@@ -4049,8 +4028,6 @@ Return Value:
         TracePrint((TRACE_LEVEL_ERROR, TRACE_FLAG_IOCTL, "DiskIoctlGetMediaTypesEx: Unable to allocate memory.\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(srb, srbSize);
 
     //
     // Send a TUR to determine if media is present.
@@ -4133,7 +4110,7 @@ Return Value:
     }
 
     modeLength = MODE_DATA_SIZE;
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                      modeLength,
                                      DISK_TAG_MODE_DATA);
 
@@ -4142,8 +4119,6 @@ Return Value:
         FREE_POOL(srb);
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(modeData, modeLength);
 
     //
     // Build the MODE SENSE CDB using previous SRB.
@@ -4329,7 +4304,7 @@ Return Value:
         //
 
         readBufferSize = fdoExtension->DiskGeometry.BytesPerSector;
-        readBuffer = ExAllocatePoolWithTag(NonPagedPoolNx,
+        readBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                            readBufferSize,
                                            DISK_TAG_SMART);
 
@@ -4553,7 +4528,7 @@ Return Value:
     } else {
         srbSize = SCSI_REQUEST_BLOCK_SIZE;
     }
-    srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 srbSize,
                                 DISK_TAG_SRB);
 
@@ -4561,8 +4536,6 @@ Return Value:
         TracePrint((TRACE_LEVEL_ERROR, TRACE_FLAG_IOCTL, "DiskIoctlVerify: Unable to allocate memory.\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(srb, srbSize);
 
     //
     // Add disk offset to starting sector.
@@ -4593,7 +4566,7 @@ Return Value:
         }
     }
 
-    Context = ExAllocatePoolWithTag(NonPagedPoolNx,
+    Context = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                     sizeof(DISK_VERIFY_WORKITEM_CONTEXT),
                                     DISK_TAG_WI_CONTEXT);
     if (Context) {
@@ -4705,7 +4678,7 @@ Return Value:
     } else {
         srbSize = SCSI_REQUEST_BLOCK_SIZE;
     }
-    srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 srbSize,
                                 DISK_TAG_SRB);
 
@@ -4713,8 +4686,6 @@ Return Value:
         TracePrint((TRACE_LEVEL_ERROR, TRACE_FLAG_IOCTL, "DiskIoctlReassignBlocks: Unable to allocate memory.\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(srb, srbSize);
 
     //
     // Build the data buffer to be transferred in the input buffer.
@@ -4912,7 +4883,7 @@ Return Value:
     } else {
         srbSize = SCSI_REQUEST_BLOCK_SIZE;
     }
-    srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 srbSize,
                                 DISK_TAG_SRB);
 
@@ -4920,8 +4891,6 @@ Return Value:
         TracePrint((TRACE_LEVEL_ERROR, TRACE_FLAG_IOCTL, "DiskIoctlReassignBlocks: Unable to allocate memory.\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(srb, srbSize);
 
     //
     // Build the data buffer to be transferred in the input buffer.
@@ -5098,7 +5067,7 @@ Return Value:
     } else {
         srbSize = SCSI_REQUEST_BLOCK_SIZE;
     }
-    srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 srbSize,
                                 DISK_TAG_SRB);
 
@@ -5106,8 +5075,6 @@ Return Value:
         TracePrint((TRACE_LEVEL_ERROR, TRACE_FLAG_IOCTL, "DiskIoctlIsWritable: Unable to allocate memory.\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(srb, srbSize);
 
     //
     // Allocate memory for a mode header and then some
@@ -5117,7 +5084,7 @@ Return Value:
     //
 
     modeLength = MODE_DATA_SIZE;
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                      modeLength,
                                      DISK_TAG_MODE_DATA);
 
@@ -5126,8 +5093,6 @@ Return Value:
         FREE_POOL(srb);
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(modeData, modeLength);
 
     //
     // Build the MODE SENSE CDB
@@ -5573,7 +5538,7 @@ Return Value:
         return STATUS_BUFFER_TOO_SMALL;
     }
 
-    srbControl = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srbControl = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                        sizeof(SRB_IO_CONTROL) +
                                        sizeof(GETVERSIONINPARAMS),
                                        DISK_TAG_SMART);
@@ -5582,8 +5547,6 @@ Return Value:
         TracePrint((TRACE_LEVEL_ERROR, TRACE_FLAG_IOCTL, "DiskIoctlSmartGetVersion: Unable to allocate memory.\n"));
         return STATUS_INSUFFICIENT_RESOURCES;
     }
-
-    RtlZeroMemory(srbControl, sizeof(SRB_IO_CONTROL) + sizeof(GETVERSIONINPARAMS));
 
     //
     // fill in srbControl fields
@@ -5774,7 +5737,7 @@ Return Value:
         return STATUS_INVALID_PARAMETER;
     }
 
-    srbControl = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srbControl = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                        sizeof(SRB_IO_CONTROL) + length,
                                        DISK_TAG_SMART);
 
@@ -6032,7 +5995,7 @@ Return Value:
     }
 
     length += max(sizeof(SENDCMDOUTPARAMS), sizeof(SENDCMDINPARAMS));
-    srbControl = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srbControl = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                        sizeof(SRB_IO_CONTROL) + length,
                                        DISK_TAG_SMART);
 

--- a/storage/class/disk/src/diskwmi.c
+++ b/storage/class/disk/src/diskwmi.c
@@ -393,7 +393,7 @@ DiskReadSmartLog(
     logSize = SectorCount * SMART_LOG_SECTOR_SIZE;
     bufferSize = sizeof(SRB_IO_CONTROL) +  max( sizeof(SENDCMDINPARAMS), sizeof(SENDCMDOUTPARAMS) - 1 + logSize );
 
-    srbControl = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srbControl = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                        bufferSize,
                                        DISK_TAG_SMART);
 
@@ -444,7 +444,7 @@ DiskWriteSmartLog(
     bufferSize = sizeof(SRB_IO_CONTROL) + sizeof(SENDCMDINPARAMS) - 1 +
                  logSize;
 
-    srbControl = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srbControl = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                        bufferSize,
                                        DISK_TAG_SMART);
 
@@ -992,7 +992,7 @@ DiskEnableInfoExceptions(
 
     modeDataSize = MODE_DATA_SIZE;
 
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                          modeDataSize,
                                          DISK_TAG_INFO_EXCEPTION);
 
@@ -1363,7 +1363,7 @@ Return Value:
 
             outBufferSize = sizeof(SRB_IO_CONTROL) + max( sizeof(SENDCMDINPARAMS), sizeof(SENDCMDOUTPARAMS) - 1 + READ_ATTRIBUTE_BUFFER_SIZE );
 
-            outBuffer = ExAllocatePoolWithTag(NonPagedPoolNx,
+            outBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                               outBufferSize,
                                               DISK_TAG_SMART);
 
@@ -1453,7 +1453,7 @@ Return Value:
 
             outBufferSize = sizeof(SRB_IO_CONTROL) + max( sizeof(SENDCMDINPARAMS), sizeof(SENDCMDOUTPARAMS) - 1 + READ_THRESHOLD_BUFFER_SIZE );
 
-            outBuffer = ExAllocatePoolWithTag(NonPagedPoolNx,
+            outBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                               outBufferSize,
                                               DISK_TAG_SMART);
 
@@ -1588,7 +1588,7 @@ DiskPostReregisterRequest(
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    reregRequest = ExAllocatePoolWithTag(NonPagedPoolNx,
+    reregRequest = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                          sizeof(DISKREREGREQUEST),
                                          DISK_TAG_SMART);
     if (reregRequest != NULL)
@@ -1934,7 +1934,7 @@ DiskInfoExceptionCheck(
     PSTOR_ADDR_BTL8 storAddrBtl8 = NULL;
     PSRBEX_DATA_SCSI_CDB16 srbExDataCdb16 = NULL;
 
-    modeData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    modeData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                      MODE_DATA_SIZE,
                                      DISK_TAG_INFO_EXCEPTION);
     if (modeData == NULL)
@@ -1949,7 +1949,7 @@ DiskInfoExceptionCheck(
     } else {
         srbSize = SCSI_REQUEST_BLOCK_SIZE;
     }
-    srb = ExAllocatePoolWithTag(NonPagedPoolNx,
+    srb = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 srbSize,
                                 DISK_TAG_SRB);
     if (srb == NULL)
@@ -1959,13 +1959,12 @@ DiskInfoExceptionCheck(
                         "buffer\n"));
         return(STATUS_INSUFFICIENT_RESOURCES);
     }
-    RtlZeroMemory(srb, srbSize);
 
     //
     // Sense buffer is in aligned nonpaged pool.
     //
 
-    senseInfoBuffer = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    senseInfoBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                             SENSE_BUFFER_SIZE_EX,
                                             '7CcS');
 

--- a/storage/class/disk/src/enum.c
+++ b/storage/class/disk/src/enum.c
@@ -82,8 +82,8 @@ DiskConvertExtendedToLayout(
         return NULL;
     }
 
-    Layout = ExAllocatePoolWithTag (
-                    NonPagedPoolNx,
+    Layout = ExAllocatePool2 (
+                    POOL_FLAG_NON_PAGED,
                     LayoutSize,
                     DISK_TAG_PART_LIST
                     );
@@ -214,8 +214,8 @@ Return Values:
         return NULL;
     }
 
-    layoutEx = ExAllocatePoolWithTag(
-                            NonPagedPoolNx,
+    layoutEx = ExAllocatePool2(
+                            POOL_FLAG_NON_PAGED,
                             size,
                             DISK_TAG_PART_LIST
                             );
@@ -342,13 +342,11 @@ Return Value:
         partitionListSize =
             FIELD_OFFSET(DRIVE_LAYOUT_INFORMATION_EX, PartitionEntry[1]);
 
-        partitionList = ExAllocatePoolWithTag(NonPagedPoolNx,
+        partitionList = ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                               partitionListSize,
                                               DISK_TAG_PART_LIST);
 
         if (partitionList != NULL) {
-
-            RtlZeroMemory( partitionList, partitionListSize );
 
             //
             // Set the partition count to one and the status to success

--- a/storage/class/disk/src/geometry.c
+++ b/storage/class/disk/src/geometry.c
@@ -328,7 +328,7 @@ DiskSaveGeometryDetectInfo(
 
     RtlInitUnicodeString(&unicodeString, L"Configuration Data");
 
-    keyData = ExAllocatePoolWithTag(PagedPool,
+    keyData = ExAllocatePool2(POOL_FLAG_PAGED,
                                     VALUE_BUFFER_SIZE,
                                     DISK_TAG_UPDATE_GEOM);
 
@@ -395,7 +395,7 @@ DiskSaveGeometryDetectInfo(
     //
 
     length = sizeof(DISK_DETECT_INFO) * numberOfDrives;
-    DetectInfoList = ExAllocatePoolWithTag(PagedPool,
+    DetectInfoList = ExAllocatePool2(POOL_FLAG_PAGED,
                                            length,
                                            DISK_TAG_UPDATE_GEOM);
 
@@ -409,8 +409,6 @@ DiskSaveGeometryDetectInfo(
     }
 
     DetectInfoCount = numberOfDrives;
-
-    RtlZeroMemory(DetectInfoList, length);
 
     //
     // Copy the information out of the key data and into the list we've
@@ -660,7 +658,7 @@ Return Value:
 
     RtlInitUnicodeString(&unicodeString, L"Identifier");
 
-    keyData = ExAllocatePoolWithTag(PagedPool,
+    keyData = ExAllocatePool2(POOL_FLAG_PAGED,
                                     VALUE_BUFFER_SIZE,
                                     DISK_TAG_UPDATE_GEOM);
 
@@ -1140,7 +1138,7 @@ Routine Description:
 
     PAGED_CODE();
 
-    readBuffer = ExAllocatePoolWithTag(NonPagedPoolNx, FdoExtension->DiskGeometry.BytesPerSector, DISK_TAG_UPDATE_GEOM);
+    readBuffer = ExAllocatePool2(POOL_FLAG_NON_PAGED, FdoExtension->DiskGeometry.BytesPerSector, DISK_TAG_UPDATE_GEOM);
 
     if (readBuffer)
     {

--- a/storage/class/disk/src/pnp.c
+++ b/storage/class/disk/src/pnp.c
@@ -281,7 +281,7 @@ Return Value:
     // Allocate request sense buffer.
     //
 
-    fdoExtension->SenseData = ExAllocatePoolWithTag(NonPagedPoolNxCacheAligned,
+    fdoExtension->SenseData = ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED,
                                                     SENSE_BUFFER_SIZE_EX,
                                                     DISK_TAG_START);
 
@@ -642,7 +642,7 @@ Return Value:
             return status;
         }
 
-    *RawName = ExAllocatePoolWithTag(PagedPool,
+    *RawName = ExAllocatePool2(POOL_FLAG_PAGED,
                                      strlen(rawName) + 1,
                                      DISK_TAG_NAME);
 


### PR DESCRIPTION
Uses the newer zero-initializing malloc APIs.

Note changes between old POOL_TYPE enum:
https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ne-wdm-_pool_type 

And new POOL_FLAGS enum:
https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/pool_flags 

Specifically, in _POOL_TYPE, non-paged pools are execuable by
default. Whereas in POOL_FLAGS, allocation of non-paged pools
must specifically request executability.

So,

- NonPagedPool -> POOL_FLAG_NON_PAGED_EXECUTE
- NonPagedPoolNx -> POOL_FLAG_NON_PAGED
- PagedPool -> POOL_FLAG_PAGED


See docs on updating old calls
https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/updating-deprecated-exallocatepool-calls 

Workitem: https://dev.azure.com/microsoft/OS/_workitems/edit/38345773/