### PR TITLE
Removing instance of ExAllocatePoolWithTag

### DIFF
--- a/bluetooth/bthecho/bthcli/sys/client.c
+++ b/bluetooth/bthecho/bthcli/sys/client.c
@@ -313,7 +313,7 @@ Return Value:
         goto exit2;
     }
 
-    serverSdpRecord = ExAllocatePoolWithTag(NonPagedPoolNx, requestSize, POOLTAG_BTHECHOSAMPLE);
+    serverSdpRecord = ExAllocatePool2(POOL_FLAG_NON_PAGED, requestSize, POOLTAG_BTHECHOSAMPLE);
     if (NULL == serverSdpRecord)
     {
         status = STATUS_INSUFFICIENT_RESOURCES;


### PR DESCRIPTION
**Why this change is needed?**
Due to the ExAllocatePool function being deprecated, we needed to update the API call to the ExAllocatePool2 function. The reason behind this change is that ExAllocatePool allocates memory that is uninitialized, users need to zero the memory before making it visible to users (Avoid leaking kernel-mode contents). In comparison, the memory that ExAllocatePool2 allocates is already zero initialized; the security risk of disclosing information is not present with this function call.

**How was this change implemented?**
The change was implemented by changing ExAllocatePoolWithTag to a ExAllocatePool2 function call. This was done with the help of the following APIs: ExAllocatePool and [ExAllocatePool2](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2)

**How was this tested?**
The driver was built using Visual Studio & WDK.