### PR TITLE
Memory leakage in message

### DIFF
--- a/filesys/miniFilter/scanner/user/scanUser.c
+++ b/filesys/miniFilter/scanner/user/scanUser.c
@@ -341,6 +341,12 @@ main (
 
     messages = malloc(sizeof(SCANNER_MESSAGE) * threadCount * requestCount);
 
+    if (messages == NULL) {
+
+        hr = ERROR_NOT_ENOUGH_MEMORY;
+        goto main_cleanup;
+    }
+    
     //
     //  Create specified number of threads.
     //

--- a/filesys/miniFilter/scanner/user/scanUser.c
+++ b/filesys/miniFilter/scanner/user/scanUser.c
@@ -376,8 +376,8 @@ main (
         }
 
         for (j = 0; j < requestCount; j++) {
-
-            PSCANNER_MESSAGE msg = &(messages[i * j]);
+        
+            PSCANNER_MESSAGE msg = &(messages[i * requestCount + j]);
 
             memset( &msg->Ovlp, 0, sizeof( OVERLAPPED ) );
 

--- a/filesys/miniFilter/scanner/user/scanUser.c
+++ b/filesys/miniFilter/scanner/user/scanUser.c
@@ -339,6 +339,10 @@ main (
     context.Port = port;
     context.Completion = completion;
 
+    //
+    //  Allocate messages.
+    //
+
     messages = malloc(sizeof(SCANNER_MESSAGE) * threadCount * requestCount);
 
     if (messages == NULL) {
@@ -372,11 +376,6 @@ main (
         }
 
         for (j = 0; j < requestCount; j++) {
-
-            //
-            //  Allocate the message.
-            //
-
 
             PSCANNER_MESSAGE msg = &(messages[i * j]);
 


### PR DESCRIPTION
"sizeof(SCANNER_MESSAGE) * threadCount * requestCount" bytes long memory is allocated but only "sizeof(SCANNER_MESSAGE) * threadCount" bytes long of it is freed.