### PR TITLE
Move the Project to the Windows Driver Compliance ready:

### DIFF
--- a/network/wlan/WDI/COMMON/common.vcxproj
+++ b/network/wlan/WDI/COMMON/common.vcxproj
@@ -50,20 +50,20 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Arm'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>
     </SupportsPackaging>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Arm'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'" Label="Configuration">
     <TargetVersion>
     </TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|Win32'">
     <TargetVersion>Win8</TargetVersion>
@@ -72,17 +72,17 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup>
     <DebuggerFlavor Condition="'$(IsKernelModeToolset)'=='true'">DbgengKernelDebugger</DebuggerFlavor>

--- a/network/wlan/WDI/PLATFORM/NDIS6/SDIO/sdio.vcxproj
+++ b/network/wlan/WDI/PLATFORM/NDIS6/SDIO/sdio.vcxproj
@@ -132,7 +132,7 @@
     <TargetVersion>
     </TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>true</SupportsPackaging>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='WinBlue Debug|Arm'">
@@ -147,7 +147,7 @@
     <TargetVersion>
     </TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>
     </SupportsPackaging>
   </PropertyGroup>
@@ -162,7 +162,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>
     </SupportsPackaging>
   </PropertyGroup>
@@ -185,7 +185,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>true</SupportsPackaging>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='WinBlue Release|Win32'">
@@ -207,7 +207,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>true</SupportsPackaging>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='WinBlue Debug|x64'">
@@ -229,7 +229,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
     <SupportsPackaging>true</SupportsPackaging>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='WinBlue Release|x64'">
@@ -877,6 +877,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="$(SolutionDir)\PLATFORM\WinInf\SDIO\x64\netrtwlans.inf" />
   </ItemGroup>
   <!-- /Necessary to pick up propper files from local directory when in the IDE-->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/network/wlan/WDI/PLATFORM/NdisComm/NdisComm.vcxproj
+++ b/network/wlan/WDI/PLATFORM/NdisComm/NdisComm.vcxproj
@@ -135,7 +135,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Arm'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|Arm'">
     <TargetVersion>Win8</TargetVersion>
@@ -148,7 +148,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Arm'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Arm'">
     <TargetVersion>Win8</TargetVersion>
@@ -161,7 +161,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|Win32'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|Win32'">
     <TargetVersion>Win8</TargetVersion>
@@ -182,7 +182,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|Win32'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|Win32'">
     <TargetVersion>Win8</TargetVersion>
@@ -203,7 +203,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Debug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Debug|x64'">
     <TargetVersion>Win8</TargetVersion>
@@ -224,7 +224,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Win10 Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>False</UseDebugLibraries>
-    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverTargetPlatform>Windows Driver</DriverTargetPlatform>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Win8 Release|x64'">
     <TargetVersion>Win8</TargetVersion>

--- a/network/wlan/WDI/PLATFORM/WinInf/SDIO/x64/netrtwlans.inf
+++ b/network/wlan/WDI/PLATFORM/WinInf/SDIO/x64/netrtwlans.inf
@@ -14,6 +14,7 @@ Signature	= "$Windows NT$"
 Class		= Net
 ClassGUID	= {4d36e972-e325-11ce-bfc1-08002be10318}
 Provider	= %Realtek%
+PnpLockdown = 1
 CatalogFile.NT	= netrtwlans.cat		;; for WHQL certified
 DriverVer = 11/23/2015,3008.22.1030.2015
 
@@ -72,35 +73,6 @@ ExcludeFromSelect = *
 %RTL8723ds.DeviceDesc% = RTL8723ds.ndi, SD\VID_024C&PID_D723
 
 ;;----------------------------------------------------------------------------
-;; Realtek 8723as default installation
-;;----------------------------------------------------------------------------
-
-             
-
-
-
-[RTL8723as.ndi.NT]
-AddReg				= NDIS_64.reg, RTL8723as.common.reg, RTLWLAN.reg, Ndis6Set.reg, 11nWirelessMode.reg, CIHVS.reg
-Include         	= netvwifibus.inf
-Needs				= VWiFiBus.CopyFiles
-Characteristics		= 0x84
-BusType				= 15 
-CopyFiles			= RTWlanS.CopyFiles
-*IfType				= 71            ; IF_TYPE_IEEE80211
-*MediaType			= 16            ; NdisMediumNative802_11
-*PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
-
-[RTL8723as.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
-Include 			= netvwifibus.inf
-Needs 				= VWiFiBus.Services
-
-[RTL8723as.ndi.NT.HW]
-Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
-
-
-;;----------------------------------------------------------------------------
 ;; Realtek 8723bs default installation
 ;;----------------------------------------------------------------------------
 
@@ -114,19 +86,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8723bs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8723bs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 ;;----------------------------------------------------------------------------
 ;; Acer 8723bs installation
 ;;----------------------------------------------------------------------------
@@ -141,19 +114,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [ACER8723bs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [ACER8723bs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 ;;----------------------------------------------------------------------------
 ;; HP 8723bs installation
 ;;----------------------------------------------------------------------------
@@ -168,19 +142,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [HP8723bs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [HP8723bs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -197,19 +172,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RSVD8723bs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RSVD8723bs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -226,19 +202,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8188es.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8188es.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -255,19 +232,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8821as.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8821as.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -284,19 +262,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8814as.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8814as.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -313,19 +292,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8192es.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8192es.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -342,19 +322,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8703bs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8703bs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -371,19 +352,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8188fs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8188fs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 ;;----------------------------------------------------------------------------
 ;; Realtek 8822bs default installation
@@ -399,19 +381,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8822bs.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8822bs.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistratio.HW
 
 
 ;;----------------------------------------------------------------------------
@@ -428,19 +411,20 @@ Include         	= netvwifibus.inf
 Needs				= VWiFiBus.CopyFiles
 Characteristics		= 0x84
 BusType				= 15 
+;CopyFiles			= RTWlanS.CopyFiles,CIHVS.CopyFiles; TODO: IF IHV provided the Rtlihvs.dll.
 CopyFiles			= RTWlanS.CopyFiles
 *IfType				= 71            ; IF_TYPE_IEEE80211
 *MediaType			= 16            ; NdisMediumNative802_11
 *PhysicalMediaType	= 9          ; NdisPhysicalMediumNative802_11
 
 [RTL8723ds.ndi.NT.Services]
-AddService			= RtlWlans, 2, RtlWlans.Service, RtlWlans.EventLog
+AddService			= RtlWlans, 0x10002, RtlWlans.Service, RtlWlans.EventLog
 Include 			= netvwifibus.inf
 Needs 				= VWiFiBus.Services
 
 [RTL8723ds.ndi.NT.HW]
 Include = netvwifibus.inf
-Needs 	= VWiFiBus.PnPFilterRegistration
+Needs 	= VWiFiBus.PnPFilterRegistration.HW
 
 ;;----------------------------------------------------------------------------
 ;; OS relative registry.
@@ -457,7 +441,7 @@ DisplayName    	= %RtlWlans.DeviceDesc.DispName%
 ServiceType    	= 1		; %SERVICE_KERNEL_DRIVER%
 StartType      	= 3		; %SERRVICE_DEMAND_START%
 ErrorControl   	= 1		; %SERRVICE_ERROR_NORMAL%
-ServiceBinary  	= %12%\rtwlans.sys
+ServiceBinary  	= %13%\rtwlans.sys
 LoadOrderGroup 	= NDIS
 
 ;;
@@ -471,33 +455,10 @@ HKR, , EventMessageFile, 0x00020000, "%%SystemRoot%%\System32\netevent.dll"
 HKR, , TypesSupported  , 0x00010001, 7
 
 [CIHVS.reg]
-HKR, Ndi\IHVExtensions, ExtensibilityDLL,       0,  "%SystemRoot%\system32\Rtlihvs.dll"
+HKR, Ndi\IHVExtensions, ExtensibilityDLL,       0,  "%13%\Rtlihvs.dll"
 HKR, Ndi\IHVExtensions, UIExtensibilityCLSID,   0,  "{6C2A8CCA-B2A2-4d81-A3B2-4E15F445C312}"
 HKR, Ndi\IHVExtensions, GroupName,              0,  "Realtek CCX SDK IHV Service"
 HKR, Ndi\IHVExtensions, AdapterOUI,             0x00010001, 0x00e04c
-
-;*******************************************************************************
-; WAPI section
-;*******************************************************************************
-[wapi.reg]
-HKR,defaults,WapiSupport,0,"1"
-HKR,,WapiSupport,0,"1"
-
-;*******************************************************************************
-; RTL8723as common paramters
-;*******************************************************************************
-[RTL8723as.common.reg]
-HKR,defaults,LedCtrl,0,"1"
-HKR,,LedCtrl,0,"1"
-
-HKR,defaults,QoS,0,"1"
-HKR,,QoS,0,"1"
-
-HKR,defaults,CcxRm,0,"1"
-HKR,,CcxRm,0,"1"
-
-HKR,defaults,CcxOffLineDurUpLimit,0,"0"
-HKR,,CcxOffLineDurUpLimit,0,"0"
 
 
 ;*******************************************************************************
@@ -605,33 +566,6 @@ HKR,,RomDLFwEnable,0,"1"
 
 HKR,defaults,bFwCtrlPwrOff,0,"1"
 HKR,,bFwCtrlPwrOff,0,"1"
-
-
-;*******************************************************************************
-; RTL8188Fs common paramters
-;*******************************************************************************
-[RTL8188fs.common.reg]
-HKR,defaults,LedCtrl,0,"1"
-HKR,,LedCtrl,0,"1"
-
-HKR,defaults,QoS,0,"1"
-HKR,,QoS,0,"1"
-
-HKR,defaults,CcxRm,0,"1"
-HKR,,CcxRm,0,"1"
-
-HKR,defaults,CcxOffLineDurUpLimit,0,"0"
-HKR,,CcxOffLineDurUpLimit,0,"0"
-
-HKR,defaults,UsbRxAggMode,0,"1"
-HKR,,UsbRxAggMode,0,"1"
-
-HKR,defaults,RomDLFwEnable,0,"0"
-HKR,,RomDLFwEnable,0,"0"
-
-HKR,defaults,bFwCtrlPwrOff,0,"1"
-HKR,,bFwCtrlPwrOff,0,"1"
-
 
 ;*******************************************************************************
 ; RTL8821as common paramters
@@ -849,22 +783,6 @@ HKR,Ndi\params\AntDiv, 			type, 		    0, "enum"
 HKR,Ndi\params\AntDiv\enum,  	"0",        	0, %DISABLED_STR%
 HKR,Ndi\params\AntDiv\enum,   	"1",        	0, %ENABLED_STR%
 
-HKLM, SYSTEM\CurrentControlSet\Services\RtlWlans\Parameters, "BtAntennaInHw", 0x00010001,2
-
-[Ndis5Set.reg]
-HKR,Ndi\params\PSPXlinkMode,			ParamDesc,  0, %PSP_XLINK_STR%
-HKR,Ndi\params\PSPXlinkMode,			type,       0, "enum"
-HKR,Ndi\params\PSPXlinkMode,			default,    0, "0"
-HKR,Ndi\params\PSPXlinkMode\enum,		"0",        0, %DISABLE_STR%
-HKR,Ndi\params\PSPXlinkMode\enum,		"1",        0, %ENABLE_STR%
-HKR,defaults,PSPXlinkMode,0,"0"
-HKR,,PSPXlinkMode,0,"0"
-
-;Inactive Power Save
-HKR,defaults,InactivePs,0,"0"
-HKR,,InactivePs,0,"0"
-
-
 [Ndis6Set.reg]
 ;Inactive Power Save
 HKR,defaults,InactivePs,0,"2"
@@ -896,19 +814,6 @@ HKR,,BWSetting,,"1"
 
 HKR,,Channel,0,"10"
 
-[11gWirelessMode.reg]
-HKR,Ndi\params\WirelessMode, 		ParamDesc, 	0, %WL_MODE_STR%
-HKR,Ndi\params\WirelessMode, 		type, 		0, "enum"
-HKR,Ndi\params\WirelessMode, 		default, 	0, "8"
-HKR,Ndi\params\WirelessMode\enum, 	"2", 		0, %IEEE_802_11B_STR%
-HKR,Ndi\params\WirelessMode\enum, 	"4", 		0, %IEEE_802_11BG_STR%
-HKR,defaults,WirelessMode, 0, "4"
-HKR,,WirelessMode, 0, "4"
-
-HKR,,BWSetting,0,"0"
-
-HKR,,Channel,0,"10"
-
 [11acWirelessMode.reg]
 HKR,Ndi\params\WirelessMode, 		ParamDesc, 	0, %WL_MODE_STR%
 HKR,Ndi\params\WirelessMode, 		type, 		0, "enum"
@@ -937,100 +842,21 @@ HKR,,BWSetting,0,"2"
 ;;----------------------------------------------------------------------------
 [32kEnable.reg]
 HKR,,bLowPowerEnable,0,"1"
-[32kDisable.reg]
-HKR,,bLowPowerEnable,0,"0"
 
 ;-------------------------------------------------------------------------------
 ;	PnP pre-transition handling
 ;-------------------------------------------------------------------------------
 [PnpPreTransOn.reg]
 HKR,,PreTransPnP,0,"1"
-[PnpPreTransOff.reg]
-HKR,,PreTransPnP,0,"0"
 
 ;;----------------------------------------------------------------------------
 ;; WOWLAN Control Parameters
 ;;----------------------------------------------------------------------------
-[WowlanAllEnable.reg]
-HKR,,WoWLANLPSLevel,0,"2"
-HKR,,ARPOffloadEnable,0,"1"
-HKR,,GTKOffloadEnable,0,"1"
-
-HKR, Ndi\params\*WakeOnMagicPacket,         ParamDesc,  0, %WakeOnMagicPacket%
-HKR, Ndi\params\*WakeOnMagicPacket,         default,    0, "1"
-HKR, Ndi\params\*WakeOnMagicPacket,         type,       0, "enum"
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "1",        0, %ENABLED_STR%
-HKR,,*WakeOnMagicPacket,0,"1"
-
-HKR, Ndi\params\*WakeOnPattern ,            ParamDesc,  0, %WakeOnPattern%
-HKR, Ndi\params\*WakeOnPattern,             default,    0, "1"
-HKR, Ndi\params\*WakeOnPattern,             type,       0, "enum"
-HKR, Ndi\params\*WakeOnPattern\enum,        "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnPattern\enum,        "1",        0, %ENABLED_STR%
-HKR,,*WakeOnPattern,0,"1"
 
 [WowlanDisable.reg]
 HKR,,WoWLANLPSLevel,0,"0"
 HKR,,ARPOffloadEnable,0,"0"
 HKR,,GTKOffloadEnable,0,"0"
-
-[WowlanAllEnableNoLPS.reg]
-HKR,,WoWLANLPSLevel,0,"0"
-HKR,,ARPOffloadEnable,0,"1"
-HKR,,GTKOffloadEnable,0,"1"
-
-HKR, Ndi\params\*WakeOnMagicPacket,         ParamDesc,  0, %WakeOnMagicPacket%
-HKR, Ndi\params\*WakeOnMagicPacket,         default,    0, "1"
-HKR, Ndi\params\*WakeOnMagicPacket,         type,       0, "enum"
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "1",        0, %ENABLED_STR%
-HKR,,*WakeOnMagicPacket,0,"1"
-
-HKR, Ndi\params\*WakeOnPattern ,            ParamDesc,  0, %WakeOnPattern%
-HKR, Ndi\params\*WakeOnPattern,             default,    0, "1"
-HKR, Ndi\params\*WakeOnPattern,             type,       0, "enum"
-HKR, Ndi\params\*WakeOnPattern\enum,        "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnPattern\enum,        "1",        0, %ENABLED_STR%
-HKR,,*WakeOnPattern,0,"1"
-
-[WowlanEnableNoPatternMatch.reg]
-HKR,,WoWLANLPSLevel,0,"2"
-HKR,,ARPOffloadEnable,0,"1"
-HKR,,GTKOffloadEnable,0,"1"
-
-HKR, Ndi\params\*WakeOnMagicPacket,         ParamDesc,  0, %WakeOnMagicPacket%
-HKR, Ndi\params\*WakeOnMagicPacket,         default,    0, "1"
-HKR, Ndi\params\*WakeOnMagicPacket,         type,       0, "enum"
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "1",        0, %ENABLED_STR%
-HKR,,*WakeOnMagicPacket,0,"1"
-
-HKR, Ndi\params\*WakeOnPattern ,            ParamDesc,  0, %WakeOnPattern%
-HKR, Ndi\params\*WakeOnPattern,             default,    0, "0"
-HKR, Ndi\params\*WakeOnPattern,             type,       0, "enum"
-HKR, Ndi\params\*WakeOnPattern\enum,        "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnPattern\enum,        "1",        0, %ENABLED_STR%
-HKR,,*WakeOnPattern,0,"0"
-
-[WowlanEnableNoLPSNoPatternMatch.reg]
-HKR,,WoWLANLPSLevel,0,"0"
-HKR,,ARPOffloadEnable,0,"1"
-HKR,,GTKOffloadEnable,0,"1"
-
-HKR, Ndi\params\*WakeOnMagicPacket,         ParamDesc,  0, %WakeOnMagicPacket%
-HKR, Ndi\params\*WakeOnMagicPacket,         default,    0, "1"
-HKR, Ndi\params\*WakeOnMagicPacket,         type,       0, "enum"
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnMagicPacket\enum,    "1",        0, %ENABLED_STR%
-HKR,,*WakeOnMagicPacket,0,"1"
-
-HKR, Ndi\params\*WakeOnPattern ,            ParamDesc,  0, %WakeOnPattern%
-HKR, Ndi\params\*WakeOnPattern,             default,    0, "0"
-HKR, Ndi\params\*WakeOnPattern,             type,       0, "enum"
-HKR, Ndi\params\*WakeOnPattern\enum,        "0",        0, %DISABLED_STR%
-HKR, Ndi\params\*WakeOnPattern\enum,        "1",        0, %ENABLED_STR%
-HKR,,*WakeOnPattern,0,"0"
 
 [ConnectedStandbyEnable.reg]
 HKR,,WoWLANLPSLevel,0,"2"
@@ -1063,31 +889,18 @@ HKR,,*PacketCoalescing,0,"0"
 ;-------------------------------------------------------------------------------
 [AutoChnlSelon.reg]
 HKR,,AutoChnlSel,0,"1"
-[AutoChnlSeloff.reg]
-HKR,,AutoChnlSel,0,"0"
 
 ;;----------------------------------------------------------------------------
 ;; RSSI to Grid Mode Parameters
 ;;----------------------------------------------------------------------------
-[RSSI2GridRealMode.reg]
-HKR,,RSSI2GridMode,0,"1"
 [RSSI2GridMode_2.reg]
 HKR,,RSSI2GridMode,0,"2"
-[RSSI2GridMode_4.reg]
-HKR,,RSSI2GridMode,0,"4"
 
 ;;----------------------------------------------------------------------------
 ;; KFREE parameters
 ;;----------------------------------------------------------------------------
 [KFREE_COMMON.reg]
 HKR,,RfKFreeEnable,0,"0"
-
-;*******************************************************************************
-; Customer reg section
-;*******************************************************************************
-[ScanType.reg]
-HKR,defaults,PassiveScan, 0, "0"
-HKR,,PassiveScan, 0, "0"
 
 ;*******************************************************************************
 ; Multi-Channel Concurrent section
@@ -1104,30 +917,26 @@ HKR,,MultiChannelFcsMode, 0, "0"
 ;*******************************************************************************
 ; Destination Directory
 ;*******************************************************************************
-[RTWlanS.CopyFiles]
-rtwlans.sys,,,2
-
 [DestinationDirs]
-DefaultDestDir     	= 11
-RTWlanS.CopyFiles	= 12
-CIHVS.CopyFiles					= 11
-RtlUI2.CopyFiles				= 10
+DefaultDestDir     	= 13
+RTWlanS.CopyFiles   = 13
+;CIHVS.CopyFiles     = 13
 
 ;;****************************************************************************
 ;; Source Files
 ;;****************************************************************************
-[CIHVS.CopyFiles]
-Rtlihvs.dll,,,2
+[RTWlanS.CopyFiles]
+rtwlans.sys,,,2
 
-[RegisterUIExt]
-11,,RtlExtUI.dll,1
-
-[RtlUI2.CopyFiles]
-RtlUI2.exe,,,2
+;TODO, The following section should be included in CopyFiles
+;      But current solution not found the Rtlihvs.dll file.
+;      so comment out;
+;[CIHVS.CopyFiles]
+;Rtlihvs.dll,,,2
 
 [SourceDisksFiles]
 rtwlans.sys = 1
-Rtlihvs.dll = 1
+;Rtlihvs.dll = 1
 
 [SourceDisksNames]
 1=%DISKNAME%,,,


### PR DESCRIPTION
1. Running the ApiValidator and make sure the issue free.
2. Running the InfVerif and make sure the INF file issue free.

There is limitations for MSFT currently doesn’t have any SDIO based WI-FI NICs, so the latest Driver Verifier /RC 33 36 tests not run