### PR TITLE
[hid\hclient] Passing right arguments to reopen device for write

### DIFF
--- a/hid/hclient/ecdisp.c
+++ b/hid/hclient/ecdisp.c
@@ -2808,8 +2808,8 @@ RoutineDescription:
     case HID_WRITE_REPORT:
 
         status = OpenHidDevice(pDevice -> DevicePath,
-                               TRUE,
                                FALSE,
+                               TRUE,
                                FALSE,
                                FALSE,
                                &writeDevice);


### PR DESCRIPTION
When reopening the device handle to write, `OpenHidDevice` is called with exactly the same arguments as is done when reopening the device for reading(just a few lines above the change for comparison).

This PR is intended to fix that.

From what I can tell this bug has been there for a looong while?