### PR TITLE
CcCoherencyFlushAndPurgeCache can fail to purge and yet return SUCCESS

### DIFF
--- a/filesys/fastfat/write.c
+++ b/filesys/fastfat/write.c
@@ -1214,7 +1214,7 @@ Return Value:
                                                 &IoStatus,
                                                 0 );
 
-                SuccessfulPurge = NT_SUCCESS( IoStatus.Status );
+                SuccessfulPurge = NT_SUCCESS( IoStatus.Status ) && (IoStatus.Status != STATUS_CACHE_PAGE_LOCKED);
 
 #else
 


### PR DESCRIPTION
As per the documentation [1]

An IoStatus->Status value of STATUS_CACHE_PAGE_LOCKED indicates that page
invalidation failed. .... Note that STATUS_CACHE_PAGE_LOCKED is a success
status (that is, testing it with the NT_SUCCESS macro would return TRUE).

[1] https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-cccoherencyflushandpurgecache