### PR TITLE
Do not use deprecated API ExAllocatePool

### DIFF
--- a/smartcrd/pscr/pscrnt.c
+++ b/smartcrd/pscr/pscrnt.c
@@ -406,8 +406,8 @@ PscrRegisterWithSmcLib(
     SmartcardExtension = &DeviceExtension->SmartcardExtension;
 
    //   allocate the reader extension
-    ReaderExtension = ExAllocatePoolWithTag(
-                                    NonPagedPoolNx,
+    ReaderExtension = ExAllocatePool2(
+                                    POOL_FLAG_NON_PAGED,
                                     sizeof( READER_EXTENSION ),
                                     SMARTCARD_POOL_TAG
                                     );


### PR DESCRIPTION
Using ExAllocatePool2 instead of deprecated API ExAllocatePool