### PR TITLE
Remove IA64 support from Print samples

### DIFF
--- a/print/OEM Printer Customization Plug-in Samples/C++/PTPCPlPr/install/ptpcplpr.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/PTPCPlPr/install/ptpcplpr.inf
@@ -20,7 +20,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Microsoft"=Microsoft, NTx86, NTamd64, NTia64
+"Microsoft"=Microsoft, NTx86, NTamd64
 
 ;
 ; Model sections. 
@@ -34,9 +34,6 @@ PnpLockdown=1
 "UniDrv PT/PC Plugin Provider"	= PTPCPLPR
 
 [Microsoft.NTamd64]
-"UniDrv PT/PC Plugin Provider"	= PTPCPLPR
-
-[Microsoft.NTia64]
 "UniDrv PT/PC Plugin Provider"	= PTPCPLPR
 
 ;
@@ -81,9 +78,6 @@ PTPCPLPR.DLL   = 100,x86
 
 [SourceDisksFiles.amd64]
 PTPCPLPR.DLL   = 100,amd64
-
-[SourceDisksFiles.IA64]
-PTPCPLPR.DLL   = 100,ia64
 
 [SourceDisksFiles]
 PTPCPLPR.GPD   = 100

--- a/print/OEM Printer Customization Plug-in Samples/C++/bitmap.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/bitmap.inf
@@ -21,7 +21,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Microsoft"=Microsoft, NTx86, NTamd64, NTia64, NTarm64
+"Microsoft"=Microsoft, NTx86, NTamd64, NTarm64
 
 ;
 ; Model sections. 
@@ -35,9 +35,6 @@ PnpLockdown=1
 "Bitmap Driver"      = BITMAP
 
 [Microsoft.NTamd64]
-"Bitmap Driver"      = BITMAP
-
-[Microsoft.NTia64]
 "Bitmap Driver"      = BITMAP
 
 [Microsoft.NTarm64]
@@ -96,9 +93,6 @@ bitmap.dll    = 100,bitmap\x86
 
 [SourceDisksFiles.amd64]
 bitmap.dll    = 100,bitmap\amd64
-
-[SourceDisksFiles.ia64]
-bitmap.dll    = 100,bitmap\ia64
 
 [SourceDisksFiles.arm64]
 bitmap.dll    = 100,bitmap\arm64

--- a/print/OEM Printer Customization Plug-in Samples/C++/gdl/res/gdlsmpl.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/gdl/res/gdlsmpl.inf
@@ -22,7 +22,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Fabrikam"=Fabrikam,NTx86,NTamd64,NTia64
+"Fabrikam"=Fabrikam,NTx86,NTamd64
 
 ;
 ; Model sections. 
@@ -36,9 +36,6 @@ PnpLockdown=1
 "GDL Sample"      = GDLSMPL
 
 [Fabrikam.NTamd64]
-"GDL Sample"      = GDLSMPL
-
-[Fabrikam.NTia64]
 "GDL Sample"      = GDLSMPL
 
 
@@ -72,9 +69,6 @@ GDLSMPL.dll    = 100,x86
 
 [SourceDisksFiles.amd64]
 GDLSMPL.dll    = 100,amd64
-
-[SourceDisksFiles.IA64]
-GDLSMPL.dll    = 100,ia64
 
 [SourceDisksFiles]
 GDLSMPL.GPD       = 100

--- a/print/OEM Printer Customization Plug-in Samples/C++/oemdll.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/oemdll.inf
@@ -22,7 +22,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Microsoft"=Microsoft, NTx86, NTamd64, NTia64, NTarm64
+"Microsoft"=Microsoft, NTx86, NTamd64, NTarm64
 
 ;
 ; Model sections. 
@@ -41,14 +41,6 @@ PnpLockdown=1
 "OEM UI Customization Sample (Unidrv)" = INSTALL_OEMUI.UNI
 
 [Microsoft.NTamd64]
-"PostScript WaterMark Sample"          = INSTALL_WATERMARK.PS
-"Unidrv WaterMark Sample"              = INSTALL_WATERMARK.UNI
-"OEM PostScript Customization Sample"  = INSTALL_OEMPS
-"OEM Unidrv Customization Sample"      = INSTALL_OEMUNI
-"OEM UI Customization Sample (PS)"     = INSTALL_OEMUI.PS
-"OEM UI Customization Sample (Unidrv)" = INSTALL_OEMUI.UNI
-
-[Microsoft.NTia64]
 "PostScript WaterMark Sample"          = INSTALL_WATERMARK.PS
 "Unidrv WaterMark Sample"              = INSTALL_WATERMARK.UNI
 "OEM PostScript Customization Sample"  = INSTALL_OEMPS
@@ -190,15 +182,6 @@ wmarkps.dll    = 100,WaterMark\amd64
 wmarkuni.dll   = 100,WaterMarkUni\amd64
 wmarkuniui.dll = 100,WaterMarkUni\amd64
 wmarkui.dll    = 100,WaterMark\amd64
-
-[SourceDisksFiles.ia64]
-oemps.dll      = 100,OEMPS\ia64
-oemui.dll      = 100,OEMUI\ia64
-oemuni.dll     = 100,OEMUNI\ia64
-wmarkps.dll    = 100,WaterMark\ia64
-wmarkuni.dll   = 100,WaterMarkUni\ia64
-wmarkuniui.dll = 100,WaterMarkUni\ia64
-wmarkui.dll    = 100,WaterMark\ia64
 
 [SourceDisksFiles.arm64]
 oemps.dll      = 100,OEMPS\arm64

--- a/print/OEM Printer Customization Plug-in Samples/C++/oemprean.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/oemprean.inf
@@ -21,7 +21,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Microsoft"=Microsoft, NTx86, NTamd64, NTia64, NTarm64
+"Microsoft"=Microsoft, NTx86, NTamd64, NTarm64
 
 ;
 ; Model sections. 
@@ -35,9 +35,6 @@ PnpLockdown=1
 "OEM Pre-Analysis sample"      = OEM_PREAN
 
 [Microsoft.NTamd64]
-"OEM Pre-Analysis sample"      = OEM_PREAN
-
-[Microsoft.NTia64]
 "OEM Pre-Analysis sample"      = OEM_PREAN
 
 [Microsoft.NTarm64]
@@ -95,9 +92,6 @@ oemprean.dll    = 100,oemprean\x86
 
 [SourceDisksFiles.amd64]
 oemprean.dll    = 100,oemprean\amd64
-
-[SourceDisksFiles.ia64]
-oemprean.dll    = 100,oemprean\ia64
 
 [SourceDisksFiles.arm64]
 oemprean.dll    = 100,oemprean\arm64

--- a/print/OEM Printer Customization Plug-in Samples/C++/uisamples.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/uisamples.inf
@@ -22,7 +22,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Microsoft"=Microsoft, NTx86, NTamd64, NTia64, NTarm64
+"Microsoft"=Microsoft, NTx86, NTamd64, NTarm64
 
 ;
 ; Model sections. 
@@ -37,10 +37,6 @@ PnpLockdown=1
 "OEM Custom Help"       = CUSTHELP.UNI
 
 [Microsoft.NTamd64]
-"OEM Custom UI Plugin"  = SYNCSET.UNI
-"OEM Custom Help"       = CUSTHELP.UNI
-
-[Microsoft.NTia64]
 "OEM Custom UI Plugin"  = SYNCSET.UNI
 "OEM Custom Help"       = CUSTHELP.UNI
 
@@ -107,10 +103,6 @@ SYNCSET.DLL   = 100,SyncSet\x86
 [SourceDisksFiles.amd64]
 CUSTHLP.DLL   = 100,CustHlp\amd64
 SYNCSET.DLL   = 100,SyncSet\amd64
-
-[SourceDisksFiles.ia64]
-CUSTHLP.DLL   = 100,CustHlp\ia64
-SYNCSET.DLL   = 100,SyncSet\ia64
 
 [SourceDisksFiles.arm64]
 CUSTHLP.DLL   = 100,CustHlp\arm64

--- a/print/OEM Printer Customization Plug-in Samples/C++/uniuirep/res/uniuirep.inf
+++ b/print/OEM Printer Customization Plug-in Samples/C++/uniuirep/res/uniuirep.inf
@@ -22,7 +22,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-"Microsoft"=Microsoft,NTx86,NTamd64,NTia64
+"Microsoft"=Microsoft,NTx86,NTamd64
 
 ;
 ; Model sections. 
@@ -36,9 +36,6 @@ PnpLockdown=1
 "Unidrv Full UI Replacement Sample"      = UNIUIREP
 
 [Microsoft.NTamd64]
-"Unidrv Full UI Replacement Sample"      = UNIUIREP
-
-[Microsoft.NTia64]
 "Unidrv Full UI Replacement Sample"      = UNIUIREP
 
 
@@ -73,11 +70,8 @@ uniuirep.dll    = 100,x86
 [SourceDisksFiles.amd64]
 uniuirep.dll    = 100,amd64
 
-[SourceDisksFiles.IA64]
-uniuirep.dll    = 100,ia64
-
 [SourceDisksFiles]
-uniuirep.GPD       = 100
+uniuirep.GPD    = 100
 uniuirep.INI    = 100
 
 ;

--- a/print/XPSDrvSmpl/install/xdsmpl.inf
+++ b/print/XPSDrvSmpl/install/xdsmpl.inf
@@ -25,21 +25,15 @@ DriverVer=10/17/2008,6.1.6930.0
 PnpLockdown=1
 
 [Manufacturer]
-%ManufacturerName%=Standard,NTx86,NTia64,NTamd64,NTx86.6.0,NTia64.6.0,NTamd64.6.0,NTarm64.6.0
+%ManufacturerName%=Standard,NTx86,NTamd64,NTx86.6.0,NTamd64.6.0,NTarm64.6.0
 
 [Standard.NTx86]
-"XPSDrv Sample Driver" = INSTALL_XDSMPL_FILTERS_PRE_VISTA
-
-[Standard.NTia64]
 "XPSDrv Sample Driver" = INSTALL_XDSMPL_FILTERS_PRE_VISTA
 
 [Standard.NTamd64]
 "XPSDrv Sample Driver" = INSTALL_XDSMPL_FILTERS_PRE_VISTA
 
 [Standard.NTx86.6.0]
-"XPSDrv Sample Driver" = INSTALL_XDSMPL_FILTERS_VISTA
-
-[Standard.NTia64.6.0]
 "XPSDrv Sample Driver" = INSTALL_XDSMPL_FILTERS_VISTA
 
 [Standard.NTamd64.6.0]
@@ -72,10 +66,6 @@ PackageAware=TRUE
 CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-4950-9ED8-A6335AFE79F5}
 
 [PrinterPackageInstallation.amd64]
-PackageAware=TRUE
-CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-4950-9ED8-A6335AFE79F5}
-
-[PrinterPackageInstallation.ia64]
 PackageAware=TRUE
 CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-4950-9ED8-A6335AFE79F5}
 
@@ -113,10 +103,6 @@ xdsmpl-pipelineconfig.xml
 [SourceDisksNames.x86]
 1 = %Location%,,
 2 = %Location%,,,x86
-
-[SourceDisksNames.ia64]
-1 = %Location%,,
-2 = %Location%,,,ia64
 
 [SourceDisksNames.amd64]
 1 = %Location%,,

--- a/print/XpsRasFilter/install/xpsrassmpl.inf
+++ b/print/XpsRasFilter/install/xpsrassmpl.inf
@@ -25,13 +25,10 @@ DriverVer=10/17/2008,6.1.6930.0
 PnpLockdown=1
 
 [Manufacturer]
-%ManufacturerName%=Standard,NTx86.6.1,NTia64.6.1,NTamd64.6.1,NTarm64.6.1
+%ManufacturerName%=Standard,NTx86.6.1,NTamd64.6.1,NTarm64.6.1
 
 
 [Standard.NTx86.6.1]
-"XPSRas WDK Sample Driver" = INSTALL_FILTER
-
-[Standard.NTia64.6.1]
 "XPSRas WDK Sample Driver" = INSTALL_FILTER
 
 [Standard.NTamd64.6.1]
@@ -56,10 +53,6 @@ CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-49
 PackageAware=TRUE
 CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-4950-9ED8-A6335AFE79F5}
 
-[PrinterPackageInstallation.ia64]
-PackageAware=TRUE
-CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-4950-9ED8-A6335AFE79F5}
-
 [PrinterPackageInstallation.arm64]
 PackageAware=TRUE
 CoreDriverDependencies={D20EA372-DD35-4950-9ED8-A6335AFE79F0}, {D20EA372-DD35-4950-9ED8-A6335AFE79F5}
@@ -75,10 +68,6 @@ xpsrasfilter.dll
 [SourceDisksNames.x86]
 1 = %Location%,,
 2 = %Location%,,,x86
-
-[SourceDisksNames.ia64]
-1 = %Location%,,
-2 = %Location%,,,ia64
 
 [SourceDisksNames.amd64]
 1 = %Location%,,

--- a/print/autoconfig/AutoCnfg.inf
+++ b/print/autoconfig/AutoCnfg.inf
@@ -22,7 +22,7 @@ PnpLockdown=1
 ; that we will display in the Dialog box
 ;
 [Manufacturer]
-%ManufacturerName%=Standard, NTx86, NTamd64, NTia64, NTarm64
+%ManufacturerName%=Standard, NTx86, NTamd64, NTarm64
 
 ;
 ; Model sections.
@@ -36,10 +36,6 @@ PnpLockdown=1
 "PScript5 AutoConfiguration Sample"  = INSTALL_AUTO_CONFIG.PS,DO_NOT_USE_THIS_HWID2
 
 [Standard.NTamd64]
-"Unidrv AutoConfiguration Sample"    = INSTALL_AUTO_CONFIG.UNI,DO_NOT_USE_THIS_HWID1
-"PScript5 AutoConfiguration Sample"  = INSTALL_AUTO_CONFIG.PS,DO_NOT_USE_THIS_HWID2
-
-[Standard.NTia64]
 "Unidrv AutoConfiguration Sample"    = INSTALL_AUTO_CONFIG.UNI,DO_NOT_USE_THIS_HWID1
 "PScript5 AutoConfiguration Sample"  = INSTALL_AUTO_CONFIG.PS,DO_NOT_USE_THIS_HWID2
 


### PR DESCRIPTION
The last release of Windows that supported IA64 was many years ago.