### PR TITLE
Remove IA64 support from more samples

### DIFF
--- a/general/toaster/toastpkg/inf/autorun.inf
+++ b/general/toaster/toastpkg/inf/autorun.inf
@@ -5,9 +5,6 @@ icon=i386\toastva.exe,0
 [AutoRun.i386]
 open=i386\toastva.exe
 
-[AutoRun.ia64]
-open=ia64\toastva.exe
-
 [AutoRun.amd64]
 open=amd64\toastva.exe
 

--- a/general/toaster/toastpkg/inf/toastpkg.inf
+++ b/general/toaster/toastpkg/inf/toastpkg.inf
@@ -16,7 +16,7 @@
 ;    INF file for installing toaster device drivers (and, optionally, value-
 ;    added software) via device-specific coinstaller.
 ;    This is a mutlios INF file. Same INF file cab be used on
-;    x86, ia64 and amd64 platforms.
+;    x86 and amd64 platforms.
 ;
 ;--*/
 [Version]
@@ -26,7 +26,6 @@ ClassGuid={B85B7C50-6A01-11d2-B841-00C04FAD5171}
 Provider=%ProviderName%
 DriverVer=09/21/2006,6.0.5736.1
 CatalogFile.NTx86  = tostx86.cat
-CatalogFile.NTIA64 = tostia64.cat
 CatalogFile.NTAMD64 = tstamd64.cat
 PnpLockdown=1
 
@@ -49,12 +48,9 @@ HKR,,DeviceCharacteristics,0x10001,0x100        ; Use same security checks on re
 ;*****************************************
 
 [Manufacturer]
-%ToastRUs%=ToastRUs,NTx86, NTia64, NTamd64
+%ToastRUs%=ToastRUs,NTx86, NTamd64
 
 [ToastRUs.NTx86]
-%ToasterDevice.DeviceDesc%=Toaster_Device, {b85b7c50-6a01-11d2-b841-00c04fad5171}\MsToaster
-
-[ToastRUs.NTia64]
 %ToasterDevice.DeviceDesc%=Toaster_Device, {b85b7c50-6a01-11d2-b841-00c04fad5171}\MsToaster
 
 [ToastRUs.NTamd64]
@@ -105,9 +101,6 @@ OriginalInfSourcePath = %1%
 
 [SourceDisksNames.x86]
 1 = %DiskId1%, toastpkg.tag,,\i386
-
-[SourceDisksNames.ia64]
-1 = %DiskId1%, toastpkg.tag,,\ia64
 
 [SourceDisksNames.amd64]
 1 = %DiskId1%, toastpkg.tag,,\amd64

--- a/general/toaster/toastpkg/toastcd/autorun.inf
+++ b/general/toaster/toastpkg/toastcd/autorun.inf
@@ -5,9 +5,6 @@ icon=i386\toastva.exe,0
 [AutoRun.i386]
 open=i386\toastva.exe
 
-[AutoRun.ia64]
-open=ia64\toastva.exe
-
 [AutoRun.amd64]
 open=amd64\toastva.exe
 

--- a/general/toaster/toastpkg/toastcd/toastpkg.inf
+++ b/general/toaster/toastpkg/toastcd/toastpkg.inf
@@ -16,7 +16,7 @@
 ;    INF file for installing toaster device drivers (and, optionally, value-
 ;    added software) via device-specific coinstaller.
 ;    This is a mutlios INF file. Same INF file cab be used on
-;    x86, ia64 and amd64 platforms.
+;    x86 and amd64 platforms.
 ;
 ;--*/
 [Version]
@@ -26,7 +26,6 @@ ClassGuid={B85B7C50-6A01-11d2-B841-00C04FAD5171}
 Provider=%ProviderName%
 DriverVer=09/21/2006,6.0.5736.1
 CatalogFile.NTx86  = tostx86.cat
-CatalogFile.NTIA64 = tostia64.cat
 CatalogFile.NTAMD64 = tstamd64.cat
 PnpLockdown=1
 
@@ -49,12 +48,9 @@ HKR,,DeviceCharacteristics,0x10001,0x100        ; Use same security checks on re
 ;*****************************************
 
 [Manufacturer]
-%ToastRUs%=ToastRUs,NTx86, NTia64, NTamd64
+%ToastRUs%=ToastRUs,NTx86, NTamd64
 
 [ToastRUs.NTx86]
-%ToasterDevice.DeviceDesc%=Toaster_Device, {b85b7c50-6a01-11d2-b841-00c04fad5171}\MsToaster
-
-[ToastRUs.NTia64]
 %ToasterDevice.DeviceDesc%=Toaster_Device, {b85b7c50-6a01-11d2-b841-00c04fad5171}\MsToaster
 
 [ToastRUs.NTamd64]
@@ -105,9 +101,6 @@ OriginalInfSourcePath = %1%
 
 [SourceDisksNames.x86]
 1 = %DiskId1%, toastpkg.tag,,\i386
-
-[SourceDisksNames.ia64]
-1 = %DiskId1%, toastpkg.tag,,\ia64
 
 [SourceDisksNames.amd64]
 1 = %DiskId1%, toastpkg.tag,,\amd64

--- a/storage/class/disk/src/diskdev.inf
+++ b/storage/class/disk/src/diskdev.inf
@@ -25,13 +25,9 @@ DefaultDestDir   = 12
 ;
 
 [Manufacturer]
-%MfgName% = Standard.Mfg, NTx86, NTia64, NTamd64
+%MfgName% = Standard.Mfg, NTx86, NTamd64
 
 [Standard.Mfg.NTx86]
-%GenDisk.DeviceDesc%    = disk, GenDisk
-%GenOptical.DeviceDesc% = disk, GenOptical
-
-[Standard.Mfg.NTia64]
 %GenDisk.DeviceDesc%    = disk, GenDisk
 %GenOptical.DeviceDesc% = disk, GenOptical
 
@@ -77,9 +73,6 @@ ServiceBinary  = %12%\disk.sys
 
 [SourceDisksNames.x86]
 1 = %DiskId1%,,,\i386
-
-[SourceDisksNames.ia64]
-1 = %DiskId1%,,,\ia64
 
 [SourceDisksNames.amd64]
 1 = %DiskId1%,,,\amd64

--- a/wia/microdrv/testmcro.inf
+++ b/wia/microdrv/testmcro.inf
@@ -16,11 +16,6 @@ testmcro.dll=1
 [SourceDisksNames.x86]
 1=%Location%,,,
 
-[SourceDisksFiles.ia64]
-testmcro.dll=1
-[SourceDisksNames.ia64]
-1=%Location%,,,
-
 [SourceDisksFiles.amd64]
 testmcro.dll=1
 [SourceDisksNames.amd64]
@@ -31,7 +26,7 @@ testmcro.dll=1
 DefaultDestDir=11
 
 [Manufacturer]
-%ManufacturerName%=Models, NTx86, NTamd64, NTia64
+%ManufacturerName%=Models, NTx86, NTamd64
 
 ; This is the models section for the x86 driver
 [Models.NTx86]
@@ -39,10 +34,6 @@ DefaultDestDir=11
 
 ; This is the models section for the amd64 driver
 [Models.NTamd64]
-%WIASample.DeviceDesc% = WIASample.Scanner, PnPIDInformation
-
-; This is the models section for the ia64 driver
-[Models.NTia64]
 %WIASample.DeviceDesc% = WIASample.Scanner, PnPIDInformation
 
 [WIASample.Scanner]


### PR DESCRIPTION
The last release of Windows that supported IA64 was many yeras ago.