### PR TITLE
Create Code-Scanning.yml

### DIFF
--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -18,7 +18,7 @@ on:
     paths-ignore:
         - '**/*.md'
         - '**/*.txt'
-        - './.github/**'
+        - '.github/**'
     
   # Allow manual scheduling
   workflow_dispatch:

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -1,0 +1,70 @@
+# This workflow runs the latest CodeQL CLI and checks against CodeQL's Cpp library.
+# It will only analyze solutions which have been changed.
+
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+      - main
+      - develop
+    
+    # Do not perform analysis if only config or text files are changed
+    paths-ignore:
+        - '**/*.md'
+        - '**/*.txt'
+        - './.github/**'
+    
+  # Allow manual scheduling
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analysis
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Get changed files
+      id: get-changed-files
+      uses: tj-actions/changed-files@v27
+
+    - name: Retrieve and build solutions from changed files
+      id: build-changed-projects
+      run: |
+        $changedFiles = "${{ steps.get-changed-files.outputs.all_changed_files }}".Split(' ')
+        .\.github\scripts\Build-ChangedProjects.ps1 -ChangedFiles $changedFiles
+      env:
+        Configuration: ${{ matrix.configuration }}
+        Platform: ${{ matrix.platform }}
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This file is identical to the existing workflow except that it has been created via the GitHub Security Code Scanning menu, which registers the workflow with the Code Scanning triggers unlike the existing workflow. If this successfully meets the Security requirements, the next commit will remove the duplicate workflow.