### PR TITLE
Update to DV-FailDriver-WDM

### DIFF
--- a/tools/dv/samples/DV-FailDriver-WDM/README.md
+++ b/tools/dv/samples/DV-FailDriver-WDM/README.md
@@ -27,17 +27,17 @@ See [Deploying a Driver to a Test Computer](https://docs.microsoft.com/windows-h
 
 #### New
 
-It is highly encouraged when testing the driver to use [DevGen](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/devgen) to create a SW device.
+It is highly encouraged when testing the driver to use [DevGen](https://learn.microsoft.com/windows-hardware/drivers/devtest/devgen) to create a `SwDevice`.
 
 __DevGen Usage Example__
 
-1. From a terminal on test computer go to the WDK tools path and run `.\devgen /add /bus SWD /hardwareid root\defect_toastmon`. ***If WDK is not available on test computer, simply copy over `devgen.exe`***
+1. From a terminal (running as admin) on test computer go to the WDK tools path and run `.\devgen /add /bus SWD /hardwareid root\defect_toastmon`. ***If WDK is not available on test computer, simply copy over `devgen.exe`***
 
-2. There is now a `Generic software device` available in the system. ***Use Device Manager as a simple means to inspect.***
+2. There is now a `Generic software device` available in the system. ***Use Device Manager as a simple means to inspect or from a terminal run `pnputil /enum-devices /deviceid "root\defect_toastmon".***
 
-3. Now that there is a device with the appropriate hardware id, deploy/install driver sample accordingly.
+3. Now that there is a device with the appropriate hardware ID, deploy/install driver sample accordingly.
 
-> Note: Use `.\devgen /remove "<Device instance path>"` to remove SW device (the path can be copied from Device Manager).
+> Note: Use `.\devgen /remove "<Device instance path>"` to remove SW device (the path can be copied from output of `.\devgen /add` or from Device Manager).
 >
 > Device instance path example `"SWD\DEVGEN\{D0299946-2EC2-C146-B00B-E01144166F8B}"`
 

--- a/tools/dv/samples/DV-FailDriver-WDM/README.md
+++ b/tools/dv/samples/DV-FailDriver-WDM/README.md
@@ -25,6 +25,22 @@ The DV-FailDriver-WDM sample driver contains intentional code errors that are de
 
 See [Deploying a Driver to a Test Computer](https://docs.microsoft.com/windows-hardware/drivers/develop/deploying-a-driver-to-a-test-computer) for details on how to deploy the sample.
 
+#### New
+
+It is highly encouraged when testing the driver to use [DevGen](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/devgen) to create a SW device.
+
+__DevGen Usage Example__
+
+1. From a terminal on test computer go to the WDK tools path and run `.\devgen /add /bus SWD /hardwareid root\defect_toastmon`. ***If WDK is not available on test computer, simply copy over `devgen.exe`***
+
+2. There is now a `Generic software device` available in the system. ***Use Device Manager as a simple means to inspect.***
+
+3. Now that there is a device with the appropriate hardware id, deploy/install driver sample accordingly.
+
+> Note: Use `.\devgen /remove "<Device instance path>"` to remove SW device (the path can be copied from Device Manager).
+>
+> Device instance path example `"SWD\DEVGEN\{D0299946-2EC2-C146-B00B-E01144166F8B}"`
+
 ## Test the sample
 
 See [How to test a driver at runtime](https://docs.microsoft.com/windows-hardware/drivers/develop/how-to-test-a-driver-at-runtime-from-a-command-prompt) for details on how to run tests on the Toastmon driver.

--- a/tools/dv/samples/DV-FailDriver-WDM/README.md
+++ b/tools/dv/samples/DV-FailDriver-WDM/README.md
@@ -27,13 +27,13 @@ See [Deploying a Driver to a Test Computer](https://docs.microsoft.com/windows-h
 
 #### New
 
-It is highly encouraged when testing the driver to use [DevGen](https://learn.microsoft.com/windows-hardware/drivers/devtest/devgen) to create a `SwDevice`.
+It is highly encouraged when testing a driver to use [DevGen](https://learn.microsoft.com/windows-hardware/drivers/devtest/devgen) to create a [SwDevice](https://learn.microsoft.com/windows/win32/api/_swdevice/).
 
 __DevGen Usage Example__
 
 1. From a terminal (running as admin) on test computer go to the WDK tools path and run `.\devgen /add /bus SWD /hardwareid root\defect_toastmon`. ***If WDK is not available on test computer, simply copy over `devgen.exe`***
 
-2. There is now a `Generic software device` available in the system. ***Use Device Manager as a simple means to inspect or from a terminal run `pnputil /enum-devices /deviceid "root\defect_toastmon".***
+2. There is now a `Generic software device` available in the system. ***Use Device Manager as a simple means to inspect or from a terminal run `pnputil /enum-devices /deviceid "root\defect_toastmon"`.***
 
 3. Now that there is a device with the appropriate hardware ID, deploy/install driver sample accordingly.
 

--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
@@ -58,9 +58,6 @@ StartType      = 1                  ; SERVICE_SYSTEM_START
 ErrorControl   = 1                  ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %12%\defect_toastmon.sys                            
 
-[DeviceInstall32]
-AddDevice=ROOT\Samples\0001,,ToastMonbuggy
-
 [ToastMonBuggy]
 HardwareIds=root\defect_toastmon
 


### PR DESCRIPTION
This change is being made to remove unsupported install for the `defect_toastmon` driver. To substitute this, documentation has been updated to encourage the use of `DevGen` as the preferred way to use the driver sample instead.