### PR TITLE
Re Configure Code-Scanning.yml

### DIFF
--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -45,10 +45,6 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Get changed files
-      id: get-changed-files
-      uses: tj-actions/changed-files@v27
-
     - name: Retrieve and build all available solutions
       id: build-all-projects
       run: |

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -1,5 +1,5 @@
 # This workflow runs the latest CodeQL CLI and checks against CodeQL's Cpp library.
-# It will only analyze solutions which have been changed.
+# This is the source for the GitHub Security Code Scanning job.
 
 name: "CodeQL Analysis"
 
@@ -13,12 +13,6 @@ on:
     branches:
       - main
       - develop
-    
-    # Do not perform analysis if only config or text files are changed
-    paths-ignore:
-        - '**/*.md'
-        - '**/*.txt'
-        - '.github/**'
     
   # Allow manual scheduling
   workflow_dispatch:
@@ -55,11 +49,10 @@ jobs:
       id: get-changed-files
       uses: tj-actions/changed-files@v27
 
-    - name: Retrieve and build solutions from changed files
-      id: build-changed-projects
+    - name: Retrieve and build all available solutions
+      id: build-all-projects
       run: |
-        $changedFiles = "${{ steps.get-changed-files.outputs.all_changed_files }}".Split(' ')
-        .\.github\scripts\Build-ChangedProjects.ps1 -ChangedFiles $changedFiles
+          .\Build-AllProjects.ps1
       env:
         Configuration: ${{ matrix.configuration }}
         Platform: ${{ matrix.platform }}


### PR DESCRIPTION
In accordance with this issue https://github.com/github/codeql-cli-binaries/issues/149 I have reconfigured to run code scanning on all PR's (to include text only changes) and adjusted the build command to build all solutions, not just the changed ones.