### PR TITLE
Fix unused warning

### DIFF
--- a/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
+++ b/tools/dv/samples/DV-FailDriver-WDM/driver/defect_toastmon.inf
@@ -58,9 +58,6 @@ StartType      = 1                  ; SERVICE_SYSTEM_START
 ErrorControl   = 1                  ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %12%\defect_toastmon.sys                            
 
-[ToastMonBuggy]
-HardwareIds=root\defect_toastmon
-
 ; ================= Source Media Section =====================
 
 [SourceDisksFiles]


### PR DESCRIPTION
- removed the [ToastMonBuggy] section to eliminate emitted warning

Verified in local build that when change is made warning is resolved.