### PR TITLE
mspassthroughext Driver compatibility violations

### DIFF
--- a/network/ndis/extension/samples/passthrough/mspassthroughext.inf
+++ b/network/ndis/extension/samples/passthrough/mspassthroughext.inf
@@ -8,7 +8,7 @@ Class       = NetService
 ClassGUID   = {4D36E974-E325-11CE-BFC1-08002BE10318}
 Provider    = %ProviderString%
 CatalogFile = mspassthroughext.cat
-DriverVer   = 08/29/2011,1.0
+DriverVer   = 08/29/2011,1.0.0.0
 PnpLockdown = 1
 
 [Manufacturer]

--- a/network/ndis/extension/samples/passthrough/mspassthroughext.inf
+++ b/network/ndis/extension/samples/passthrough/mspassthroughext.inf
@@ -39,8 +39,8 @@ Copyfiles = MSPassthroughExt.copyfiles.sys
 MSPassthroughExt.sys=1
 
 [DestinationDirs]
-DefaultDestDir=12
-MSPassthroughExt.copyfiles.sys=12
+DefaultDestDir=13
+MSPassthroughExt.copyfiles.sys=13
 
 [MSPassthroughExt.copyfiles.sys]
 MSPassthroughExt.sys,,,2
@@ -72,7 +72,7 @@ DisplayName     = %MSPassthroughExt_Desc%
 ServiceType     = 1 ;SERVICE_KERNEL_DRIVER
 StartType       = 1 ;SERVICE_SYSTEM_START
 ErrorControl    = 1 ;SERVICE_ERROR_NORMAL
-ServiceBinary   = %12%\MSPassthroughExt.sys
+ServiceBinary   = %13%\MSPassthroughExt.sys
 LoadOrderGroup  = NDIS
 Description     = %MSPassthroughExt_Desc%
 

--- a/network/ndis/extension/samples/passthrough/mspassthroughext.inf
+++ b/network/ndis/extension/samples/passthrough/mspassthroughext.inf
@@ -9,6 +9,7 @@ ClassGUID   = {4D36E974-E325-11CE-BFC1-08002BE10318}
 Provider    = %ProviderString%
 CatalogFile = mspassthroughext.cat
 DriverVer   = 08/29/2011,1.0
+PnpLockdown = 1
 
 [Manufacturer]
 %ManufacturerName%=Standard,NTx86,NTia64,NTamd64


### PR DESCRIPTION
Fixed three INF Driver compatibility violations. Used the included install.cmd and uninstall.cmd to confirm that the install and uninstall completes, and the Driver Store is used. 