### PR TITLE
Enable the CodeQL workflow to pull submodules similar to the regular workflow.

### DIFF
--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        submodules: 'recursive'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
Enable the CodeQL workflow to pull submodules similar to the regular workflow.

This also removes a "fetch-depth: 0" that as far as I understand documentation of "checkout" has been taking up unnecessary disk space.