### PR TITLE
serenum sample: Use ExAllocatePool2 instead of ExAllocatePoolWithTag

### DIFF
--- a/serial/serenum/enum.c
+++ b/serial/serenum/enum.c
@@ -230,7 +230,7 @@ SerenumDoEnumProtocol(
    LOGENTRY(LOG_ENUM, 'SDEP', PFdoData,  PpBuf, PDSRMissing);
 
 
-   pReadBuf = ExAllocatePoolWithTag(NonPagedPoolNx, MAX_DEVNODE_NAME + sizeof(CHAR) ,SERENUM_POOL_TAG);
+   pReadBuf = ExAllocatePoolZero(NonPagedPoolNx, MAX_DEVNODE_NAME + sizeof(CHAR) ,SERENUM_POOL_TAG);
    
    if (pReadBuf == NULL) {
       status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1580,7 +1580,7 @@ Return Value:
 
     length = sizeof(KEY_VALUE_FULL_INFORMATION) + KeyNameStringLength
       + DataLength;
-    fullInfo = ExAllocatePoolWithTag(PagedPool, length,SERENUM_POOL_TAG);
+    fullInfo = ExAllocatePoolZero(PagedPool, length,SERENUM_POOL_TAG);
 
     if (ActualLength != NULL) {
        *ActualLength = 0;

--- a/serial/serenum/log.c
+++ b/serial/serenum/log.c
@@ -146,7 +146,7 @@ Return Value:
 
     KeInitializeSpinLock(&LogSpinLock);
 
-    SerenumLStart = ExAllocatePoolWithTag(NonPagedPoolNx, logSize, 'mneS');
+    SerenumLStart = ExAllocatePoolZero(NonPagedPoolNx, logSize, 'mneS');
 
     if (SerenumLStart) {
         SerenumLPtr = SerenumLStart;


### PR DESCRIPTION
Use ExAllocatePool2 instead of ExAllocatePoolWithTag