### PR TITLE
add missing PAGED_CODE() macro

### DIFF
--- a/filesys/fastfat/dirsup.c
+++ b/filesys/fastfat/dirsup.c
@@ -2575,6 +2575,8 @@ Return Value:
 --*/
 
 {
+    PAGED_CODE();
+    
     try {
     
         FatSetFileSizeInDirent( IrpContext, Fcb, AlternativeFileSize );

--- a/filesys/fastfat/verfysup.c
+++ b/filesys/fastfat/verfysup.c
@@ -1487,6 +1487,8 @@ FatMatchFileSize (
 
     UNREFERENCED_PARAMETER(IrpContext);
 
+    PAGED_CODE();
+
     if (NodeType(Fcb) != FAT_NTC_FCB) {
         return TRUE;
     }


### PR DESCRIPTION
This fixes 43490675 - Missing PAGED_CODE() macros in GitHub Repo Windows Driver Samples: filesys/fastfat/dirsup.c and verfysup.c