### PR TITLE
Enable the Control-flow Enforcement Technology (CET) Shadow Stack mit…

### DIFF
--- a/network/ndis/extension/samples/passthrough/mspassthroughext.vcxproj
+++ b/network/ndis/extension/samples/passthrough/mspassthroughext.vcxproj
@@ -82,6 +82,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ndis.lib;.\..\..\base\$(IntDir)\sxbase.lib</AdditionalDependencies>
+      <CETCompat>true</CETCompat>
     </Link>
     <ClCompile>
       <TreatWarningAsError>true</TreatWarningAsError>


### PR DESCRIPTION
Running BinSkim.exe revealed warning BA2025. The Control-flow Enforcement Technology (CET) Shadow Stack mitigation was not enabled on this project. CETCOMPAT is now set to true. 