### PR TITLE
Enable the Control-flow Enforcement Technology (CET) Shadow Stack mit…

### DIFF
--- a/network/ndis/netvmini/6x/60/netvmini60.vcxproj
+++ b/network/ndis/netvmini/6x/60/netvmini60.vcxproj
@@ -121,6 +121,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ndis.lib</AdditionalDependencies>
+      <CETCompat>true</CETCompat>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/network/ndis/netvmini/6x/620/netvmini620.vcxproj
+++ b/network/ndis/netvmini/6x/620/netvmini620.vcxproj
@@ -121,6 +121,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ndis.lib</AdditionalDependencies>
+      <CETCompat>true</CETCompat>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/network/ndis/netvmini/6x/630/netvmini630.vcxproj
+++ b/network/ndis/netvmini/6x/630/netvmini630.vcxproj
@@ -121,6 +121,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ndis.lib</AdditionalDependencies>
+      <CETCompat>true</CETCompat>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/network/ndis/netvmini/6x/680/netvmini680.vcxproj
+++ b/network/ndis/netvmini/6x/680/netvmini680.vcxproj
@@ -121,6 +121,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\ndis.lib</AdditionalDependencies>
+      <CETCompat>true</CETCompat>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>


### PR DESCRIPTION
Enable the Control-flow Enforcement Technology (CET) Shadow Stack mitigation for each netvmini60, netvmini620, netvmini630, and netvmini680 projects. 