### PR TITLE
Patch rare infinite loops when enumerating USB_COMMON_DESCRIPTORs 

### DIFF
--- a/usb/usbsamp/exe/testapp.c
+++ b/usb/usbsamp/exe/testapp.c
@@ -1052,7 +1052,8 @@ Return Value:
         commonDesc = (PUSB_COMMON_DESCRIPTOR)cd;
 
         while ((PUCHAR)commonDesc + sizeof(USB_COMMON_DESCRIPTOR) < descEnd &&
-           (PUCHAR)commonDesc + commonDesc->bLength <= descEnd)
+           (PUCHAR)commonDesc + commonDesc->bLength <= descEnd &&
+           commonDesc->bLength > 0)
         {
             displayUnknown = FALSE;
 

--- a/usb/usbview/display.c
+++ b/usb/usbview/display.c
@@ -4428,7 +4428,8 @@ IsUVCDevice (
 
     // walk through all the descriptors looking for the VIDEO_CONTROL_HEADER_UNIT
     while ((PUCHAR)commonDesc + sizeof(USB_COMMON_DESCRIPTOR) < descEnd &&
-        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd)
+        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd &&
+        commonDesc->bLength > 0)
     {
         if ((commonDesc->bDescriptorType == CS_INTERFACE) &&
             (commonDesc->bLength > sizeof(VIDEO_CONTROL_HEADER_UNIT)))
@@ -4490,7 +4491,8 @@ IsIADDevice (
 
     // return total number of IAD descriptors in this device configuration
     while ((PUCHAR)commonDesc + sizeof(USB_COMMON_DESCRIPTOR) < descEnd &&
-        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd)
+        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd &&
+        commonDesc->bLength > 0)
     {
         if (commonDesc->bDescriptorType == USB_IAD_DESCRIPTOR_TYPE)
         {

--- a/usb/usbview/dispvid.c
+++ b/usb/usbview/dispvid.c
@@ -5523,7 +5523,8 @@ GetVCInterfaceSize (
     // return this interface's sum of descriptor lengths
     //   starting from this header until (and not including) the first endpoint
     while ((PUCHAR)commonDesc + sizeof(USB_COMMON_DESCRIPTOR) < descEnd &&
-        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd)
+        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd &&
+        commonDesc->bLength > 0)
     {
         if (commonDesc->bDescriptorType == USB_ENDPOINT_DESCRIPTOR_TYPE)
             break;

--- a/usb/usbview/enum.c
+++ b/usb/usbview/enum.c
@@ -2278,7 +2278,8 @@ AreThereStringDescriptors (
     commonDesc = (PUSB_COMMON_DESCRIPTOR)ConfigDesc;
 
     while ((PUCHAR)commonDesc + sizeof(USB_COMMON_DESCRIPTOR) < descEnd &&
-           (PUCHAR)commonDesc + commonDesc->bLength <= descEnd)
+           (PUCHAR)commonDesc + commonDesc->bLength <= descEnd &&
+           commonDesc->bLength > 0)
     {
         switch (commonDesc->bDescriptorType)
         {

--- a/usb/usbview/xmlhelper.cpp
+++ b/usb/usbview/xmlhelper.cpp
@@ -1715,7 +1715,8 @@ array < UsbDeviceConfigurationType ^> ^ XmlGetConfigDescriptors(
     descEnd = (PUCHAR) configDescs + configDescs->wTotalLength;
 
     while ((PUCHAR)commonDesc + sizeof(USB_COMMON_DESCRIPTOR) < descEnd &&
-        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd)
+        (PUCHAR)commonDesc + commonDesc->bLength <= descEnd &&
+        commonDesc->bLength > 0)
     {
         // Add the config descriptor
         deviceConf = gcnew UsbDeviceConfigurationType();


### PR DESCRIPTION
It turns out there are some devices for which the USB_COMMON_DESCRIPTOR can have a valid pointer but no data (length 0). If this occurs, it can cause an infinite loop in many places where this general code pattern for enumerating USB_COMMON_DESCRIPTORs is repeated throughout the current samples. This change appears to resolve the issue, though I am not 100% certain it does so in an ideal way? I hope it's a quick enough review :)