### PR TITLE
[avstream/sampledevicemft] Fix possible deadlock while changes output stream state

### DIFF
--- a/avstream/sampledevicemft/common.h
+++ b/avstream/sampledevicemft/common.h
@@ -177,6 +177,8 @@ public:
     ~CCritSec();
     _Requires_lock_not_held_(m_criticalSection) _Acquires_lock_(m_criticalSection)
     void Lock();
+    _Requires_lock_not_held_(m_criticalSection) _Acquires_lock_(m_criticalSection)
+    BOOL TryLock();
     _Requires_lock_held_(m_criticalSection) _Releases_lock_(m_criticalSection)
     void Unlock();
 };
@@ -199,6 +201,22 @@ public:
     CAutoLock(CCritSec* crit);
     _Releases_lock_(this->m_pCriticalSection->m_criticalSection)
     ~CAutoLock();
+};
+
+class CTryLock
+{
+protected:
+    CCritSec    *m_pCriticalSection;
+    BOOL        m_bLocked;
+public:
+    _Acquires_lock_(this->m_pCriticalSection->m_criticalSection)
+    CTryLock(CCritSec& crit);
+    _Acquires_lock_(this->m_pCriticalSection->m_criticalSection)
+    CTryLock(CCritSec* crit);
+    _Releases_lock_(this->m_pCriticalSection->m_criticalSection)
+    ~CTryLock();
+
+    BOOL Locked();
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/avstream/sampledevicemft/multipinmft.cpp
+++ b/avstream/sampledevicemft/multipinmft.cpp
@@ -774,7 +774,11 @@ output pins and populate the corresponding MFT_OUTPUT_DATA_BUFFER with the sampl
     {
         DWORD dwStreamID = pOutputSamples[i].dwStreamID;
         {
-            CAutoLock _lock(m_critSec);
+            CTryLock _lock(m_critSec);
+            if (!_lock.Locked())
+            {
+                break;
+            }
             spOpin = nullptr;
             spOpin = GetOutPin(dwStreamID);
             GUID     pinGuid = GUID_NULL;

--- a/avstream/sampledevicemft/multipinmftutils.cpp
+++ b/avstream/sampledevicemft/multipinmftutils.cpp
@@ -34,6 +34,12 @@ void CCritSec::Lock()
     EnterCriticalSection(&m_criticalSection);
 }
 
+_Requires_lock_not_held_(m_criticalSection) _Acquires_lock_(m_criticalSection)
+BOOL CCritSec::TryLock()
+{
+    return TryEnterCriticalSection(&m_criticalSection);
+}
+
 _Requires_lock_held_(m_criticalSection) _Releases_lock_(m_criticalSection)
 void CCritSec::Unlock()
 {
@@ -57,6 +63,32 @@ _Releases_lock_(this->m_pCriticalSection->m_criticalSection)
 CAutoLock::~CAutoLock()
 {
     m_pCriticalSection->Unlock();
+}
+
+_Acquires_lock_(this->m_pCriticalSection->m_criticalSection)
+CTryLock::CTryLock(CCritSec& crit)
+{
+    m_pCriticalSection = &crit;
+    m_bLocked = m_pCriticalSection->TryLock();
+}
+_Acquires_lock_(this->m_pCriticalSection->m_criticalSection)
+CTryLock::CTryLock(CCritSec* crit)
+{
+    m_pCriticalSection = crit;
+    m_bLocked = m_pCriticalSection->TryLock();
+}
+_Releases_lock_(this->m_pCriticalSection->m_criticalSection)
+CTryLock::~CTryLock()
+{
+    if (m_bLocked)
+    {
+        m_pCriticalSection->Unlock();
+    }
+}
+
+BOOL CTryLock::Locked()
+{
+    return m_bLocked;
 }
 
 //


### PR DESCRIPTION
prerequisites:
There are multiple output streams.
BUG:
In the CMultipinMft::ProcessOutput function, when the first stream object is obtained and executed to spOpin->ProcessOutput, SetOutputStreamState may be executed at the same time to change the stream state. The latter acquires the lock and begins to wait for the Input stream state change. At this point, the CMultipinMft::ProcessOutput function starts to process the second stream, and cannot acquire the lock. Finally, the DTM deadlock...