### PR TITLE
[network/trans/stmedit] Fix architecture in solution

### DIFF
--- a/exclusions.csv
+++ b/exclusions.csv
@@ -5,7 +5,6 @@ general\dchu\osrfx2_dchu_extension_tight,Wrong Toolset - needs migration
 general\simplemediasource,ARM64 LNK1181: cannot open input file 'SimpleMediaSource.lib'
 general\winhec 2017 lab\toaster driver,Needs input from end user
 general\winhec 2017 lab\toaster support app,Needs input from end user
-network\trans\stmedit,Invalid Win32 architecture
 network\trans\wfpsampler,Missing INF section; missing libs
 network\wlan\wdi,Invalid architecture
 print\oem printer customization plug-in samples\c++,Invalid architecture

--- a/network/trans/stmedit/stmedit.sln
+++ b/network/trans/stmedit/stmedit.sln
@@ -15,9 +15,9 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|Win32.ActiveCfg = Debug|Win32
 		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|Win32.Build.0 = Debug|Win32
-		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|x64.ActiveCfg = Release|Win32
-		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|x64.Build.0 = Release|Win32
-		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|x64.Deploy.0 = Release|Win32
+		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|x64.ActiveCfg = Release|x64
+		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|x64.Build.0 = Release|x64
+		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Debug|x64.Deploy.0 = Release|x64
 		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Release|Win32.ActiveCfg = Release|Win32
 		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Release|Win32.Build.0 = Release|Win32
 		{9CE912A5-6210-4EF8-B22D-611D13254D4C}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
When building the solution, Debug|x64 was treated as Debug|Win32 in the stmedit project. This has been fixed and the exclusion related to this error has been removed.