### PR TITLE
[general/simplemediasource] Fix architecture in solution

### DIFF
--- a/exclusions.csv
+++ b/exclusions.csv
@@ -2,7 +2,6 @@ Path,Reason
 general\dchu\osrfx2_dchu_base,Wrong Toolset - needs migration
 general\dchu\osrfx2_dchu_extension_loose,Needs fix for project not found
 general\dchu\osrfx2_dchu_extension_tight,Wrong Toolset - needs migration
-general\simplemediasource,ARM64 LNK1181: cannot open input file 'SimpleMediaSource.lib'
 general\winhec 2017 lab\toaster driver,Needs input from end user
 general\winhec 2017 lab\toaster support app,Needs input from end user
 network\trans\stmedit,Invalid Win32 architecture

--- a/general/SimpleMediaSource/SimpleMediaSource.sln
+++ b/general/SimpleMediaSource/SimpleMediaSource.sln
@@ -19,8 +19,10 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|ARM.ActiveCfg = Debug|Win32
-		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|ARM.ActiveCfg = Debug|ARM
+		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|ARM.Build.0 = Debug|ARM
+		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|ARM64.Build.0 = Debug|ARM64
 		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|x64.ActiveCfg = Debug|x64
 		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|x64.Build.0 = Debug|x64
 		{43AD9BF7-E765-48FE-9826-71A8F2CB12DD}.Debug|x86.ActiveCfg = Debug|Win32


### PR DESCRIPTION
When building the solution, Debug|ARM64 was treated as Debug|Win32 in the simplemediasource project. This has been fixed and the exclusion related to this error has been removed.