### PR TITLE
Add logs as artifacts for actions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,10 +31,16 @@ jobs:
           separator: ","
 
       - name: Retrieve and build solutions from changed files
-        id: build-changed-samples
         run: |
           $changedFiles = "${{ steps.get-changed-files.outputs.all_changed_files }}".Split(',')
           .\.github\scripts\Build-ChangedSamples.ps1 -ChangedFiles $changedFiles -Verbose
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
+
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: logs
+          path: _logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,15 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Retrieve and build all available solutions
-        id: build-all-samples
         run: |
           .\Build-AllSamples.ps1 -Verbose
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
+
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: logs
+          path: _logs

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -20,7 +20,7 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
 }
 
 New-Item -ItemType Directory -Force -Path $LogFilesDirectory | Out-Null
-$sampleBuilderFilePath = "$LogFilesDirectory\overview.htm"
+$sampleBuilderFilePath = "$LogFilesDirectory\_overview.htm"
 
 
 Remove-Item  -Recurse -Path $LogFilesDirectory 2>&1 | Out-Null

--- a/Building-Locally.md
+++ b/Building-Locally.md
@@ -72,5 +72,5 @@ Excluded:             56
 Unsupported:          230
 Failed:               0
 Log files directory:  .\_logs
-Overview report:      .\_logs\overview.htm
+Overview report:      .\_logs\_overview.htm
 ```


### PR DESCRIPTION
With this change, logs generated by the build actions will be archived for 90 days for users to download and review.

* Small change to the generated overview report name so it appears on top of a sorted file list.