### PR TITLE
Update MsBuild action

### DIFF
--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -43,10 +43,9 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Retrieve and build all available solutions
-      id: build-all-samples
       run: |
           .\Build-AllSamples.ps1 -Verbose -ThrottleLimit 1
       env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
 
       - name: Get changed files
         id: get-changed-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
 
       - name: Retrieve and build all available solutions
         id: build-all-samples


### PR DESCRIPTION
Update setup-msbuild action to version 1.3.1 to clear errors about deprecated output methods.