### PR TITLE
Add custom build tool for msg.mc to fix compile failure.

### DIFF
--- a/setup/devcon/devcon.vcxproj
+++ b/setup/devcon/devcon.vcxproj
@@ -246,6 +246,17 @@
     <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
     <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
     <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
+    <CustomBuild Include="msg.mc">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mc.exe %(Identity)</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Filename).h;%(Filename).rc</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mc.exe %(Identity)</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Filename).h;%(Filename).rc</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mc.exe %(Identity)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mc.exe %(Identity)</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(Filename).h;%(Filename).rc</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Filename).h;%(Filename).rc</Outputs>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Exclude="@(ClInclude)" Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd" />

--- a/setup/devcon/devcon.vcxproj.Filters
+++ b/setup/devcon/devcon.vcxproj.Filters
@@ -30,4 +30,17 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="*.h;*.hpp;*.hxx;*.hm;*.inl;*.xsd">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="msg.mc">
+      <Filter>Resource Files</Filter>
+    </CustomBuild>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Failure log as follows. But I can not add custom build tool for ARM64, does anyone know what to do?

> Build started...
1>------ Build started: Project: devcon, Configuration: Debug x64 ------
1>cmds.cpp
1>D:\github\Windows-driver-samples\setup\devcon\devcon.h(31,10): fatal  error C1083: Cannot open include file: 'msg.h': No such file or directory
1>devcon.cpp
1>D:\github\Windows-driver-samples\setup\devcon\devcon.h(31,10): fatal  error C1083: Cannot open include file: 'msg.h': No such file or directory
1>dump.cpp
1>D:\github\Windows-driver-samples\setup\devcon\devcon.h(31,10): fatal  error C1083: Cannot open include file: 'msg.h': No such file or directory
1>Generating Code...
1>Done building project "devcon.vcxproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
========== Build started at 8:01 PM and took 01.706 seconds ==========

