### PR TITLE
Generate and provide overview reports

### DIFF
--- a/.github/scripts/Join-CsvReports.ps1
+++ b/.github/scripts/Join-CsvReports.ps1
@@ -1,7 +1,8 @@
+$logsPath = Join-Path (Get-Location).Path "_logs"
 $idProperty = 'Sample'
 $results = $null
 
-Get-ChildItem -Path (Get-Location).Path -Filter '*.csv' | ForEach-Object {
+Get-ChildItem -Path $logsPath -Filter '*.csv' | ForEach-Object {
     $csv = Import-Csv -Path $_
     if ($results -eq $null) {
         $results = $csv
@@ -29,5 +30,5 @@ Get-ChildItem -Path (Get-Location).Path -Filter '*.csv' | ForEach-Object {
     }
 }
 
-$results | ConvertTo-Csv | Out-File "_global_overview.csv"
-$results | ConvertTo-Html -Title "Overview" | Out-File "_global_overview.htm"
+$results | ConvertTo-Csv | Out-File "$logsPath\_global_overview.csv"
+$results | ConvertTo-Html -Title "Overview" | Out-File "$logsPath\_global_overview.htm"

--- a/.github/scripts/Join-CsvReports.ps1
+++ b/.github/scripts/Join-CsvReports.ps1
@@ -1,0 +1,33 @@
+$idProperty = 'Sample'
+$results = $null
+
+Get-ChildItem -Path (Get-Location).Path -Filter '*.csv' | ForEach-Object {
+    $csv = Import-Csv -Path $_
+    if ($results -eq $null) {
+        $results = $csv
+    }
+    else {
+        $results = $csv | ForEach-Object {
+            $id = $_.$idProperty
+            $match = $results | Where-Object { $_.$idProperty -eq $id }
+            if ($match) {
+                $properties = $_ | Get-Member -MemberType NoteProperty | Where-Object { $_.Name -ne $idProperty } | Select-Object -ExpandProperty Name
+                $newObject = New-Object PSObject
+                # Add ID property separately to ensure it appears first
+                $newObject | Add-Member -MemberType NoteProperty -Name $idProperty -Value $_.$idProperty
+                foreach ($property in $properties) {
+                    $newObject | Add-Member -MemberType NoteProperty -Name $property -Value $_.$property
+                }
+                foreach ($property in ($match | Get-Member -MemberType NoteProperty | Where-Object { $_.Name -ne $idProperty } | Select-Object -ExpandProperty Name)) {
+                    if ($properties -notcontains $property) {
+                        $newObject | Add-Member -MemberType NoteProperty -Name $property -Value $match.$property
+                    }
+                }
+                $newObject
+            }
+        }
+    }
+}
+
+$results | ConvertTo-Csv | Out-File "_global_overview.csv"
+$results | ConvertTo-Html -Title "Overview" | Out-File "_global_overview.htm"

--- a/.github/scripts/Join-CsvReports.ps1
+++ b/.github/scripts/Join-CsvReports.ps1
@@ -1,4 +1,5 @@
 $logsPath = Join-Path (Get-Location).Path "_logs"
+$reportFileName = '_overview.all'
 $idProperty = 'Sample'
 $results = $null
 
@@ -30,5 +31,5 @@ Get-ChildItem -Path $logsPath -Filter '*.csv' | ForEach-Object {
     }
 }
 
-$results | ConvertTo-Csv | Out-File "$logsPath\_global_overview.csv"
-$results | ConvertTo-Html -Title "Overview" | Out-File "$logsPath\_global_overview.htm"
+$results | ConvertTo-Csv | Out-File (Join-Path $logsPath "$reportFileName.csv")
+$results | ConvertTo-Html -Title "Overview" | Out-File (Join-Path $logsPath "$reportFileName.htm")

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -71,4 +71,3 @@ jobs:
         with:
           name: logs
           path: _logs/_overview.all.*
-  

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,9 +38,46 @@ jobs:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
 
-      - name: Archive logs
+      - name: Archive build logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: logs
+          path: |
+            _logs/*.out
+            _logs/*.wrn
+            _logs/*.err
+  
+      - name: Archive overview build reports
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: overview
+          path: |
+            _logs/_overview_${{ matrix.configuration }}_${{ matrix.platform }}.*
+  
+  report:
+    name: Generate global report
+    runs-on: windows-2022
+    needs: build
+    if: always()
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Retrieve overview reports
+        uses: actions/download-artifact@v3
+        with:
+          name: overview
           path: _logs
+
+      - name: Join and generate global reports
+        run: |
+          .\.github\scripts\Join-CsvReports.ps1
+
+      - name: Archive global overview build reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: overview
+          path: _logs/_global_overview.*
+  

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,6 +9,7 @@ on:
       - 'LICENSE'
 jobs:
   build:
+    name: Build driver samples
     strategy:
       fail-fast: false
       matrix:
@@ -37,24 +38,14 @@ jobs:
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
+          WDS_ReportFileName: _overview.${{ matrix.configuration }}.${{ matrix.platform }}
 
-      - name: Archive build logs
+      - name: Archive build logs and overview build reports
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: logs
-          path: |
-            _logs/*.out
-            _logs/*.wrn
-            _logs/*.err
-  
-      - name: Archive overview build reports
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: overview
-          path: |
-            _logs/_overview_${{ matrix.configuration }}_${{ matrix.platform }}.*
+          path: _logs
   
   report:
     name: Generate global report
@@ -68,7 +59,7 @@ jobs:
       - name: Retrieve overview reports
         uses: actions/download-artifact@v3
         with:
-          name: overview
+          name: logs
           path: _logs
 
       - name: Join and generate global reports
@@ -78,6 +69,6 @@ jobs:
       - name: Archive global overview build reports
         uses: actions/upload-artifact@v3
         with:
-          name: overview
-          path: _logs/_global_overview.*
+          name: logs
+          path: _logs/_overview.all.*
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,24 +31,14 @@ jobs:
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
+          WDS_ReportFileName: _overview.${{ matrix.configuration }}.${{ matrix.platform }}
 
-      - name: Archive build logs
+      - name: Archive build logs and overview build reports
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: logs
-          path: |
-            _logs/*.out
-            _logs/*.wrn
-            _logs/*.err
-
-      - name: Archive overview build reports
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: overview
-          path: |
-            _logs/_overview_${{ matrix.configuration }}_${{ matrix.platform }}.*
+          path: _logs
 
   report:
     name: Generate global report
@@ -62,7 +52,7 @@ jobs:
       - name: Retrieve overview reports
         uses: actions/download-artifact@v3
         with:
-          name: overview
+          name: logs
           path: _logs
 
       - name: Join and generate global reports
@@ -72,5 +62,5 @@ jobs:
       - name: Archive global overview build reports
         uses: actions/upload-artifact@v3
         with:
-          name: overview
-          path: _logs/_global_overview.*
+          name: logs
+          path: _logs/_overview.all.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
     needs: build
     if: always()
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
       - name: Retrieve overview reports
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - develop
-      - test
     paths-ignore:
       - '**.md'
       - 'LICENSE'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - 'LICENSE'
 jobs:
   build:
+    name: Build driver samples
     strategy:
       fail-fast: false
       matrix:
@@ -36,4 +37,38 @@ jobs:
         if: always()
         with:
           name: logs
+          path: |
+            _logs/*.out
+            _logs/*.wrn
+            _logs/*.err
+
+      - name: Archive overview reports
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: overview
+          path: |
+            _logs/_overview_${{ matrix.configuration }}_${{ matrix.platform }}.*
+
+  report:
+    name: Generate global report
+    runs-on: windows-2022
+    needs: build
+    if: always()
+    steps:
+      - name: Retrieve overview reports
+        uses: actions/download-artifact@v3
+        with:
+          name: overview
           path: _logs
+
+      - name: Join and generate global reports
+        run: |
+          .\.github\scripts\Join-CsvReports.ps1
+        working-directory: _logs
+
+      - name: Archive global overview reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: overview
+          path: _logs/_global_overview.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
 
-      - name: Archive logs
+      - name: Archive build logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -43,7 +43,7 @@ jobs:
             _logs/*.wrn
             _logs/*.err
 
-      - name: Archive overview reports
+      - name: Archive overview build reports
         uses: actions/upload-artifact@v3
         if: always()
         with:
@@ -66,9 +66,8 @@ jobs:
       - name: Join and generate global reports
         run: |
           .\.github\scripts\Join-CsvReports.ps1
-        working-directory: _logs
 
-      - name: Archive global overview reports
+      - name: Archive global overview build reports
         uses: actions/upload-artifact@v3
         with:
           name: overview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - develop
+      - test
     paths-ignore:
       - '**.md'
       - 'LICENSE'

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+_logs
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -19,8 +19,13 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
     $Verbose = $PsBoundParameters.Get_Item('Verbose')
 }
 
+$overviewFileName = "_overview"
+if ($Configurations.Count -eq 1 -and $Platforms.Count -eq 1) {
+    $overviewFileName += "_$($Configurations)_$($Platforms)"
+}
 New-Item -ItemType Directory -Force -Path $LogFilesDirectory | Out-Null
-$sampleBuilderFilePath = "$LogFilesDirectory\_overview.htm"
+$overviewFilePath = "$LogFilesDirectory\$overviewFileName.htm"
+$overviewCsvFilePath = "$LogFilesDirectory\$overviewFileName.csv"
 
 
 Remove-Item  -Recurse -Path $LogFilesDirectory 2>&1 | Out-Null
@@ -205,8 +210,9 @@ Write-Output "Excluded:             $SolutionsExcluded"
 Write-Output "Unsupported:          $SolutionsUnsupported"
 Write-Output "Failed:               $SolutionsFailed"
 Write-Output "Log files directory:  $LogFilesDirectory"
-Write-Output "Overview report:      $sampleBuilderFilePath"
+Write-Output "Overview report:      $overviewFilePath"
 Write-Output ""
 
-$Results | Sort-Object { $_.Sample } | ConvertTo-Html -Title "Overview" | Out-File $sampleBuilderFilePath
-Invoke-Item $sampleBuilderFilePath
+$Results | Sort-Object { $_.Sample } | ConvertTo-Csv | Out-File $overviewCsvFilePath
+$Results | Sort-Object { $_.Sample } | ConvertTo-Html -Title "Overview" | Out-File $overviewFilePath
+Invoke-Item $overviewFilePath

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -4,7 +4,7 @@ param(
     [string[]]$Configurations = @(if ([string]::IsNullOrEmpty($env:WDS_Configuration)) { "Debug" } else { $env:WDS_Configuration }),
     [string[]]$Platforms = @(if ([string]::IsNullOrEmpty($env:WDS_Platform)) { "x64" } else { $env:WDS_Platform }),
     $LogFilesDirectory = (Get-Location),
-    [string]$ReportFileName = $env:WDS_ReportFileName,
+    [string]$ReportFileName = $(if ([string]::IsNullOrEmpty($env:WDS_ReportFileName)) { "_overview" } else { $env:WDS_ReportFileName }),
     [int]$ThrottleLimit = 0
 )
 
@@ -20,9 +20,6 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
     $Verbose = $PsBoundParameters.Get_Item('Verbose')
 }
 
-if ([string]::IsNullOrEmpty($ReportFileName)) {
-    $ReportFileName = "_overview"
-}
 New-Item -ItemType Directory -Force -Path $LogFilesDirectory | Out-Null
 $reportFilePath = Join-Path $LogFilesDirectory "$ReportFileName.htm"
 $reportCsvFilePath = Join-Path $LogFilesDirectory "$ReportFileName.csv"

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -4,7 +4,7 @@ param(
     [string[]]$Configurations = @(if ([string]::IsNullOrEmpty($env:WDS_Configuration)) { "Debug" } else { $env:WDS_Configuration }),
     [string[]]$Platforms = @(if ([string]::IsNullOrEmpty($env:WDS_Platform)) { "x64" } else { $env:WDS_Platform }),
     $LogFilesDirectory = (Get-Location),
-    [string]$ReportFileName = (if ([string]::IsNullOrEmpty($env:WDS_ReportFileName)) { "_overview" } else { $env:WDS_ReportFileName }),
+    [string]$ReportFileName = $env:WDS_ReportFileName,
     [int]$ThrottleLimit = 0
 )
 
@@ -20,6 +20,9 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
     $Verbose = $PsBoundParameters.Get_Item('Verbose')
 }
 
+if ([string]::IsNullOrEmpty($ReportFileName)) {
+    $ReportFileName = "_overview"
+}
 New-Item -ItemType Directory -Force -Path $LogFilesDirectory | Out-Null
 $reportFilePath = Join-Path $LogFilesDirectory "$ReportFileName.htm"
 $reportCsvFilePath = Join-Path $LogFilesDirectory "$ReportFileName.csv"

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -4,6 +4,7 @@ param(
     [string[]]$Configurations = @(if ([string]::IsNullOrEmpty($env:WDS_Configuration)) { "Debug" } else { $env:WDS_Configuration }),
     [string[]]$Platforms = @(if ([string]::IsNullOrEmpty($env:WDS_Platform)) { "x64" } else { $env:WDS_Platform }),
     $LogFilesDirectory = (Get-Location),
+    [string]$ReportFileName = (if ([string]::IsNullOrEmpty($env:WDS_ReportFileName)) { "_overview" } else { $env:WDS_ReportFileName }),
     [int]$ThrottleLimit = 0
 )
 
@@ -19,13 +20,9 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
     $Verbose = $PsBoundParameters.Get_Item('Verbose')
 }
 
-$overviewFileName = "_overview"
-if ($Configurations.Count -eq 1 -and $Platforms.Count -eq 1) {
-    $overviewFileName += "_$($Configurations)_$($Platforms)"
-}
 New-Item -ItemType Directory -Force -Path $LogFilesDirectory | Out-Null
-$overviewFilePath = "$LogFilesDirectory\$overviewFileName.htm"
-$overviewCsvFilePath = "$LogFilesDirectory\$overviewFileName.csv"
+$reportFilePath = Join-Path $LogFilesDirectory "$ReportFileName.htm"
+$reportCsvFilePath = Join-Path $LogFilesDirectory "$ReportFileName.csv"
 
 
 Remove-Item  -Recurse -Path $LogFilesDirectory 2>&1 | Out-Null
@@ -210,9 +207,9 @@ Write-Output "Excluded:             $SolutionsExcluded"
 Write-Output "Unsupported:          $SolutionsUnsupported"
 Write-Output "Failed:               $SolutionsFailed"
 Write-Output "Log files directory:  $LogFilesDirectory"
-Write-Output "Overview report:      $overviewFilePath"
+Write-Output "Overview report:      $reportFilePath"
 Write-Output ""
 
-$Results | Sort-Object { $_.Sample } | ConvertTo-Csv | Out-File $overviewCsvFilePath
-$Results | Sort-Object { $_.Sample } | ConvertTo-Html -Title "Overview" | Out-File $overviewFilePath
-Invoke-Item $overviewFilePath
+$Results | Sort-Object { $_.Sample } | ConvertTo-Csv | Out-File $reportCsvFilePath
+$Results | Sort-Object { $_.Sample } | ConvertTo-Html -Title "Overview" | Out-File $reportFilePath
+Invoke-Item $reportFilePath


### PR DESCRIPTION
Build scripts provide a build report at the end of a run. These reports, one per combination of configuration and architecture, will now be submitted as a downloadable artifact. Moreover, at the end of a run, a global report condensing the other local reports will be generated as well by joining the other reports.

Testing was done in my local fork of the repository (results [here](https://github.com/NeoAdonis/Windows-driver-samples/actions)),