### PR TITLE
Firefly driver: Postpone variable definitions until first use

### DIFF
--- a/hid/firefly/driver/device.c
+++ b/hid/firefly/driver/device.c
@@ -53,13 +53,6 @@ Return Value:
 
 --*/    
 {
-    WDF_OBJECT_ATTRIBUTES           attributes;
-    NTSTATUS                        status;
-    PDEVICE_CONTEXT                 pDeviceContext;
-    WDFDEVICE                       device;
-    WDFMEMORY                       memory;
-    size_t                          bufferLength;
-
     UNREFERENCED_PARAMETER(Driver);
 
     PAGED_CODE();
@@ -69,9 +62,11 @@ Return Value:
     //
     WdfFdoInitSetFilter(DeviceInit);
 
+    WDF_OBJECT_ATTRIBUTES attributes;
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes, DEVICE_CONTEXT);
 
-    status = WdfDeviceCreate(&DeviceInit, &attributes, &device);
+    WDFDEVICE device;
+    NTSTATUS status = WdfDeviceCreate(&DeviceInit, &attributes, &device);
     if (!NT_SUCCESS(status)) {
         KdPrint(("FireFly: WdfDeviceCreate, Error %x\n", status));
         return status;
@@ -80,7 +75,7 @@ Return Value:
     //
     // Driver Framework always zero initializes an objects context memory
     //
-    pDeviceContext = WdfObjectGet_DEVICE_CONTEXT(device);
+    PDEVICE_CONTEXT pDeviceContext = WdfObjectGet_DEVICE_CONTEXT(device);
 
     //
     // Initialize our WMI support
@@ -104,6 +99,7 @@ Return Value:
     //
     attributes.ParentObject = device;
 
+    WDFMEMORY memory;
     status = WdfDeviceAllocAndQueryProperty(device,
                                     DevicePropertyPhysicalDeviceObjectName,
                                     NonPagedPoolNx,
@@ -115,6 +111,7 @@ Return Value:
         return STATUS_UNSUCCESSFUL;
     }
 
+    size_t bufferLength;
     pDeviceContext->PdoName.Buffer = WdfMemoryGetBuffer(memory, &bufferLength);
 
     if (pDeviceContext->PdoName.Buffer == NULL) {

--- a/hid/firefly/driver/driver.c
+++ b/hid/firefly/driver/driver.c
@@ -35,12 +35,10 @@ DriverEntry(
     IN PUNICODE_STRING RegistryPath
     )
 {
-    WDF_DRIVER_CONFIG params;
-    NTSTATUS  status;
-
     KdPrint(("FireFly: DriverEntry - WDF version built on %s %s\n", 
                             __DATE__, __TIME__));
 
+    WDF_DRIVER_CONFIG params;
     WDF_DRIVER_CONFIG_INIT(
                         &params,
                         FireFlyEvtDeviceAdd
@@ -50,7 +48,7 @@ DriverEntry(
     // Create the framework WDFDRIVER object, with the handle
     // to it returned in Driver.
     //
-    status = WdfDriverCreate(DriverObject, 
+    NTSTATUS status = WdfDriverCreate(DriverObject, 
                              RegistryPath, 
                              WDF_NO_OBJECT_ATTRIBUTES, 
                              &params, 

--- a/hid/firefly/driver/vfeature.c
+++ b/hid/firefly/driver/vfeature.c
@@ -68,27 +68,16 @@ Return Value:
 
 --*/
 {
-    WDF_MEMORY_DESCRIPTOR       inputDescriptor, outputDescriptor;
-    NTSTATUS                    status;
-    HID_COLLECTION_INFORMATION  collectionInformation = {0};
-    PHIDP_PREPARSED_DATA        preparsedData;
-    HIDP_CAPS                   caps;
-    USAGE                       usage;
-    ULONG                       usageLength;
-    PCHAR                       report;
-    WDFIOTARGET                 hidTarget;
-    WDF_IO_TARGET_OPEN_PARAMS   openParams;
-
     PAGED_CODE();
 
     //
     // Preinit for error.
     //
-    preparsedData = NULL;
-    report = NULL;
-    hidTarget = NULL;
+    PHIDP_PREPARSED_DATA preparsedData = NULL;
+    PCHAR                report = NULL;
+    WDFIOTARGET          hidTarget = NULL;
     
-    status = WdfIoTargetCreate(WdfObjectContextGetObject(DeviceContext), 
+    NTSTATUS status = WdfIoTargetCreate(WdfObjectContextGetObject(DeviceContext), 
                             WDF_NO_OBJECT_ATTRIBUTES, 
                             &hidTarget);    
     if (!NT_SUCCESS(status)) {
@@ -99,6 +88,7 @@ Return Value:
     //
     // Open it up, write access only!
     //
+    WDF_IO_TARGET_OPEN_PARAMS openParams;
     WDF_IO_TARGET_OPEN_PARAMS_INIT_OPEN_BY_NAME(
                                     &openParams,
                                     &DeviceContext->PdoName,
@@ -117,6 +107,8 @@ Return Value:
     }
     
 
+    WDF_MEMORY_DESCRIPTOR      outputDescriptor;
+    HID_COLLECTION_INFORMATION collectionInformation = {0};
     WDF_MEMORY_DESCRIPTOR_INIT_BUFFER(&outputDescriptor,
                                       (PVOID) &collectionInformation,
                                       sizeof(HID_COLLECTION_INFORMATION));
@@ -165,6 +157,7 @@ Return Value:
     //
     // Now get the capabilities.
     //
+    HIDP_CAPS caps;
     RtlZeroMemory(&caps, sizeof(HIDP_CAPS));
 
     status = HidP_GetCaps(preparsedData, &caps);
@@ -195,8 +188,8 @@ Return Value:
         //
         // Edit the report to reflect the enabled feature
         //
-        usage = FeatureId;
-        usageLength = 1;
+        USAGE usage = FeatureId;
+        ULONG usageLength = 1;
 
         status = HidP_SetUsages(
             HidP_Feature,
@@ -214,6 +207,7 @@ Return Value:
         }
     }
 
+    WDF_MEMORY_DESCRIPTOR inputDescriptor;
     WDF_MEMORY_DESCRIPTOR_INIT_BUFFER(&inputDescriptor,
                                       report,
                                       caps.FeatureReportByteLength);

--- a/hid/firefly/driver/wmi.c
+++ b/hid/firefly/driver/wmi.c
@@ -41,32 +41,30 @@ WmiInitialize(
     PDEVICE_CONTEXT DeviceContext
     )
 {
-    WDF_WMI_PROVIDER_CONFIG providerConfig;
-    WDF_WMI_INSTANCE_CONFIG instanceConfig;
-    WDF_OBJECT_ATTRIBUTES woa;
-    WDFWMIINSTANCE instance;
-    NTSTATUS status;
     DECLARE_CONST_UNICODE_STRING(mofRsrcName, MOFRESOURCENAME);
 
     UNREFERENCED_PARAMETER(DeviceContext);
 
     PAGED_CODE();
 
-    status = WdfDeviceAssignMofResourceName(Device, &mofRsrcName);
+    NTSTATUS status = WdfDeviceAssignMofResourceName(Device, &mofRsrcName);
     if (!NT_SUCCESS(status)) {
         KdPrint(("FireFly: Error in WdfDeviceAssignMofResourceName %x\n", status));
         return status;
     }
 
+    WDF_WMI_PROVIDER_CONFIG providerConfig;
     WDF_WMI_PROVIDER_CONFIG_INIT(&providerConfig, &FireflyDeviceInformation_GUID);
     providerConfig.MinInstanceBufferSize = sizeof(FireflyDeviceInformation);
 
+    WDF_WMI_INSTANCE_CONFIG instanceConfig;
     WDF_WMI_INSTANCE_CONFIG_INIT_PROVIDER_CONFIG(&instanceConfig, &providerConfig);
     instanceConfig.Register = TRUE;
     instanceConfig.EvtWmiInstanceQueryInstance = EvtWmiInstanceQueryInstance;
     instanceConfig.EvtWmiInstanceSetInstance = EvtWmiInstanceSetInstance;
     instanceConfig.EvtWmiInstanceSetItem = EvtWmiInstanceSetItem;
 
+    WDF_OBJECT_ATTRIBUTES woa;
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&woa, FireflyDeviceInformation);
 
     //
@@ -74,6 +72,7 @@ WmiInitialize(
     // passed back in the WMI instance callbacks and is not referenced outside
     // of those callbacks.
     //
+    WDFWMIINSTANCE instance;
     status = WdfWmiInstanceCreate(Device, &instanceConfig, &woa, &instance);
 
     if (NT_SUCCESS(status)) {


### PR DESCRIPTION
Motivation:
* Improves readability and maintainability.
* Have been supported since C99.
* _Can_ potentially reduce stack size usage when variable usage is confined to a local scope. Example: `usage` and `usageLength` variables in hid/firefly/driver/vfeature.c. The compiler is probably already optimizing this though.

Downside:
* It's a bit more cumbersome to manually determine the stack size of a function when all local variables are no longer listed together. However, tools can still do this effectively.