### PR TITLE
Firefly: Configure Inf2CatUseLocalTime to fix build failure right after midnight

### DIFF
--- a/hid/firefly/driver/firefly.vcxproj
+++ b/hid/firefly/driver/firefly.vcxproj
@@ -86,15 +86,19 @@
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>firefly</TargetName>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <TargetName>firefly</TargetName>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>firefly</TargetName>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <TargetName>firefly</TargetName>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>


### PR DESCRIPTION
Done to fix the following error when building between midnight and 2AM on a computer configured in the GMT+2 time-zone:
`>22.9.7: DriverVer set to a date in the future (postdated DriverVer not allowed) in firefly\firefly.inf.`

Problem description: https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/inf2cat#troubleshooting . The [SDIO](https://github.com/microsoft/Windows-driver-samples/blob/main/network/wlan/WDI/PLATFORM/NDIS6/SDIO/sdio.vcxproj) sample is already with the same Inf2CatUseLocalTime parameter, so the pattern is not new to this repo.