### PR TITLE
Remove UMDF references from toastDrv readme

### DIFF
--- a/general/toaster/toastDrv/README.md
+++ b/general/toaster/toastDrv/README.md
@@ -1,6 +1,6 @@
 ---
 page_type: sample
-description: "An iterative series of samples that demonstrate KDMF and UDMF1 driver development."
+description: "An iterative series of samples that demonstrate KMDF driver development."
 languages:
 - cpp
 products:
@@ -10,7 +10,7 @@ products:
 
 # Toaster Sample Driver
 
-The Toaster collection is an iterative series of samples that demonstrate fundamental aspects of Windows driver development for both Kernel-Mode Driver Framework (KMDF).
+The Toaster collection is an iterative series of samples that demonstrate fundamental aspects of Windows driver development for Kernel-Mode Driver Framework (KMDF).
 
 All the samples work with a hypothetical toaster bus, over which toaster devices can be connected to a PC.
 


### PR DESCRIPTION
Remove the misspelled "UDMF1" reference, since all UMDF projects were removed in #830. All remaining drivers in this solution are now KMDF-based.

Also, rename the misspelled "KDMF" acronym to "KMDF".