### PR TITLE
develop_branch_exclusion_list_cleanup

### DIFF
--- a/Build-Sample.ps1
+++ b/Build-Sample.ps1
@@ -139,7 +139,7 @@ $OutLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.out"
 
 Write-Verbose "Building Sample: $SampleName; Configuration: $Configuration; Platform: $Platform {"
 
-msbuild $solutionFile -clp:Verbosity=m -t:clean,build -property:Configuration=$Configuration -property:Platform=$Platform -p:TargetVersion=Windows10 -p:InfVerif_AdditionalOptions="/sw*" -p:SignToolWS=/fdws -p:DriverCFlagAddOn=/wd4996 -flp1:errorsonly`;logfile=$errorLogFilePath -flp2:WarningsOnly`;logfile=$warnLogFilePath -noLogo -warnAsError > $OutLogFilePath
+msbuild $solutionFile -clp:Verbosity=m -t:clean,build -property:Configuration=$Configuration -property:Platform=$Platform -p:TargetVersion=Windows10 -p:InfVerif_AdditionalOptions="/sw* /samples /msft /sw1205 /sw1324 /sw1420 /sw1421 /sw2086" -p:SignToolWS=/fdws -p:DriverCFlagAddOn=/wd4996 -flp1:errorsonly`;logfile=$errorLogFilePath -flp2:WarningsOnly`;logfile=$warnLogFilePath -noLogo -warnAsError > $OutLogFilePath
 if ($env:WDS_WipeOutputs -ne $null)
 {
     Write-Verbose ("WipeOutputs: "+$Directory+" "+(((Get-Volume ($DriveLetter=(Get-Item ".").PSDrive.Name)).SizeRemaining/1GB)))

--- a/Build-Sample.ps1
+++ b/Build-Sample.ps1
@@ -139,7 +139,7 @@ $OutLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.out"
 
 Write-Verbose "Building Sample: $SampleName; Configuration: $Configuration; Platform: $Platform {"
 
-msbuild $solutionFile -clp:Verbosity=m -t:clean,build -property:Configuration=$Configuration -property:Platform=$Platform -p:TargetVersion=Windows10 -p:InfVerif_AdditionalOptions="/samples /msft /sw1205 /sw1324 /sw1420 /sw1421 /sw2086" -p:SignToolWS=/fdws -p:DriverCFlagAddOn=/wd4996 -flp1:errorsonly`;logfile=$errorLogFilePath -flp2:WarningsOnly`;logfile=$warnLogFilePath -noLogo > $OutLogFilePath
+msbuild $solutionFile -clp:Verbosity=m -t:clean,build -property:Configuration=$Configuration -property:Platform=$Platform -p:TargetVersion=Windows10 -p:InfVerif_AdditionalOptions="/sw*" -p:SignToolWS=/fdws -p:DriverCFlagAddOn=/wd4996 -flp1:errorsonly`;logfile=$errorLogFilePath -flp2:WarningsOnly`;logfile=$warnLogFilePath -noLogo -warnAsError > $OutLogFilePath
 if ($env:WDS_WipeOutputs -ne $null)
 {
     Write-Verbose ("WipeOutputs: "+$Directory+" "+(((Get-Volume ($DriveLetter=(Get-Item ".").PSDrive.Name)).SizeRemaining/1GB)))

--- a/exclusions.csv
+++ b/exclusions.csv
@@ -1,9 +1,6 @@
 Path,Reason
-storage\class\disk, InfVerif error 1233: Missing directive CatalogFile required for digital signature
 general\dchu\osrfx2_dchu_extension_loose,Needs fix for project not found
 general\dchu\osrfx2_dchu_extension_tight,InfVerif error 1144: Device software with SoftwareType 1 may not execute on all product types
-general\winhec 2017 lab\toaster driver,Needs input from end user
 general\winhec 2017 lab\toaster support app,Needs input from end user
-network\trans\wfpsampler,Missing INF section; missing libs
+network\trans\wfpsampler,compile error
 tree,Missing headers
-video\indirectdisplay,ARM64 Warning C4530: C++ exception handler used but unwind semantics are not enabled

--- a/exclusions.csv
+++ b/exclusions.csv
@@ -2,5 +2,6 @@ Path,Reason
 general\dchu\osrfx2_dchu_extension_loose,Needs fix for project not found
 general\dchu\osrfx2_dchu_extension_tight,InfVerif error 1144: Device software with SoftwareType 1 may not execute on all product types
 general\winhec 2017 lab\toaster support app,Needs input from end user
-network\trans\wfpsampler,compile error
+network\trans\wfpsampler,missing libs
 tree,Missing headers
+video\indirectdisplay,ARM64 Warning C4530: C++ exception handler used but unwind semantics are not enabled


### PR DESCRIPTION
Add -warnAsError to build.
Change infverif to /sw* so as to not have EEAP samples broken by changes to infverif.
Remove entries from exclusion list so as to compile as many drivers as possible.