### PR TITLE
simbatt: Clear BATTERY_CAPACITY_RELATIVE field for per-battery charge display

### DIFF
--- a/simbatt/func/miniclass.c
+++ b/simbatt/func/miniclass.c
@@ -239,9 +239,7 @@ Return Value:
         DevExt->State.BatteryStatus.Capacity = 100;
         DevExt->State.BatteryStatus.Voltage = BATTERY_UNKNOWN_VOLTAGE;
         DevExt->State.BatteryStatus.Rate = 0;
-        DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY |
-                                                 BATTERY_CAPACITY_RELATIVE;
-
+        DevExt->State.BatteryInfo.Capabilities = BATTERY_SYSTEM_BATTERY;
         DevExt->State.BatteryInfo.Technology = 1;
         DevExt->State.BatteryInfo.Chemistry[0] = 'F';
         DevExt->State.BatteryInfo.Chemistry[1] = 'a';


### PR DESCRIPTION
Clear [`BATTERY_INFORMATION::BATTERY_CAPACITY_RELATIVE`](https://learn.microsoft.com/en-us/windows/win32/power/battery-information-str) field to enable per-battery charge display in Windows Settings when simulating multi-battery setups.

## Motivating example
Example of simulated multi-battery setup prior to this PR:
![image](https://github.com/microsoft/Windows-driver-samples/assets/2671400/11cbd017-d25a-44b5-8254-b40036e15694)
As you can see, the individual batteries report 0% despite being fully charged. The aggregated 100% charge is however correct.

Corresponding example after clearing the `BATTERY_CAPACITY_RELATIVE` field:
![image](https://github.com/microsoft/Windows-driver-samples/assets/2671400/1113c08c-8bcc-4ba4-a950-fd107847f23a)
As you can see, the individual batteries now correctly report 100%.

## Testing instructions
Steps:
*  Modify the `SimBattPrepareHardware` function in miniclass.c so that the `!` negation is removed from `if (!NT_SUCCESS(Status)) {` on the line after `Status = GetSimBattStateFromRegistry(Device, RegState);
`. This will ensure that default settings are loaded when registry read-back fails.
* Build simbatt project.
* From an admin command-prompt run `devcon.exe /r install simbatt.inf "{6B34C467-CE1F-4c0d-A3E4-F98A5718A9D6}\SimBatt"` to install the driver and create a simulated battery. Repeat the call to create additional batteries.

To clean up afterwards. run `devcon.exe /r remove "{6B34C467-CE1F-4c0d-A3E4-F98A5718A9D6}\SimBatt"` followed by `PNPUTIL /delete-driver simbatt.inf /uninstall /force /reboot` from an admin comand-prompt.