### PR TITLE
simbatt: Fix broken registry read-back

### DIFF
--- a/simbatt/func/miniclass.c
+++ b/simbatt/func/miniclass.c
@@ -202,7 +202,7 @@ Return Value:
     }
 
     Status = GetSimBattStateFromRegistry(Device, RegState);
-    if (!NT_SUCCESS(Status)) {
+    if (NT_SUCCESS(Status)) {
 
         RtlZeroMemory(RegState, sizeof(SIMBATT_STATE));
         WdfWaitLockAcquire(DevExt->StateLock, NULL);


### PR DESCRIPTION
The `GetSimBattStateFromRegistry` function is currently using default settings if `GetSimBattStateFromRegistry` succeeds, whereas settings from registry are only applied if `GetSimBattStateFromRegistry` fails. This does not make sense to me.

Therefore proposing to remove the `!` negation from `if (!NT_SUCCESS(Status)) {` on the line after `Status = GetSimBattStateFromRegistry(Device, RegState);` so that default settings are loaded when registry read-back fails.