### PR TITLE
moufiltr: Mirror mouse movement

### DIFF
--- a/input/moufiltr/moufiltr.c
+++ b/input/moufiltr/moufiltr.c
@@ -487,6 +487,15 @@ Return Value:
     PDEVICE_EXTENSION   devExt;
     WDFDEVICE   hDevice;
 
+    // mirror mouse events in queue
+    for (MOUSE_INPUT_DATA* id = InputDataStart; id != InputDataEnd; ++id) {
+        if (!(id->Flags & MOUSE_MOVE_ABSOLUTE)) {
+            // invert relative mouse movement
+            id->LastX = -id->LastX;
+            id->LastY = -id->LastY;
+        }
+    }
+
     hDevice = WdfWdmDeviceGetWdfDeviceHandle(DeviceObject);
 
     devExt = FilterGetData(hDevice);


### PR DESCRIPTION
Make the driver more interesting by mirroring mouse events, so that left movement becomes right, up movement becomes down, and so on.

Using `MOUSE_MOVE_ABSOLUTE`(1) instead of `MOUSE_MOVE_RELATIVE`(0) to allow bitmask operations.
