### PR TITLE
Build System: Catch Sporadic Failures

### DIFF
--- a/Build-Sample.ps1
+++ b/Build-Sample.ps1
@@ -145,7 +145,7 @@ $myexit=0
 # Let us build up to three times (0th, 1st, and 2nd attempt).
 # If we succeed at first, then it is a success.
 # If we fail at first, but succeed at either of next two attempts, then it is a sporadic failure.
-# Finally if we even at third attempt fail, then it is a true failure.
+# If we even at third attempt fail, then it is a true failure.
 #
 for ($i=0; $i -le 2; $i++) {
     $errorLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.$i.err"

--- a/Build-Sample.ps1
+++ b/Build-Sample.ps1
@@ -134,29 +134,75 @@ foreach ($line in Get-Content -Path $solutionFile)
 if (-not $configurationIsSupported)
 {
     Write-Verbose "[$SampleName] `u{23E9} Skipped. Configuration $Configuration|$Platform not supported."
-    exit 2
+    exit 3
 }
-
-$errorLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.err"
-$warnLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.wrn"
-$OutLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.out"
 
 Write-Verbose "Building Sample: $SampleName; Configuration: $Configuration; Platform: $Platform {"
-msbuild $solutionFile -clp:Verbosity=m -t:rebuild -property:Configuration=$Configuration -property:Platform=$Platform -p:TargetVersion=Windows10 -p:InfVerif_AdditionalOptions="$InfVerif_AdditionalOptions" -warnaserror -flp1:errorsonly`;logfile=$errorLogFilePath -flp2:WarningsOnly`;logfile=$warnLogFilePath -noLogo > $OutLogFilePath
-if ($env:WDS_WipeOutputs -ne $null)
-{
-    Write-Verbose ("WipeOutputs: "+$Directory+" "+(((Get-Volume ($DriveLetter=(Get-Item ".").PSDrive.Name)).SizeRemaining/1GB)))
-    Get-ChildItem -path $Directory -Recurse -Include x64|Remove-Item -Recurse
-    Get-ChildItem -path $Directory -Recurse -Include arm64|Remove-Item -Recurse
+
+$myexit=0
+
+#
+# Let us build up to three times (0th, 1st, and 2nd attempt).
+# If we succeed at first, then it is a success.
+# If we fail at first, but succeed at either of next two attempts, then it is a sporadic failure.
+# Finally if we even at third attempt fail, then it is a true failure.
+#
+for ($i=0; $i -le 2; $i++) {
+    $errorLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.$i.err"
+    $warnLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.$i.wrn"
+    $OutLogFilePath = "$LogFilesDirectory\$SampleName.$Configuration.$Platform.$i.out"
+
+    msbuild $solutionFile -clp:Verbosity=m -t:rebuild -property:Configuration=$Configuration -property:Platform=$Platform -p:TargetVersion=Windows10 -p:InfVerif_AdditionalOptions="$InfVerif_AdditionalOptions" -warnaserror -flp1:errorsonly`;logfile=$errorLogFilePath -flp2:WarningsOnly`;logfile=$warnLogFilePath -noLogo > $OutLogFilePath
+    if ($env:WDS_WipeOutputs -ne $null)
+    {
+        Write-Verbose ("WipeOutputs: "+$Directory+" "+(((Get-Volume ($DriveLetter=(Get-Item ".").PSDrive.Name)).SizeRemaining/1GB)))
+        Get-ChildItem -path $Directory -Recurse -Include x64|Remove-Item -Recurse
+        Get-ChildItem -path $Directory -Recurse -Include arm64|Remove-Item -Recurse
+    }
+    if ($LASTEXITCODE -eq 0)
+    {
+        # We succeeded building. 
+        # If at first attempt, then $myexit=0
+        # If at later attempt, then $myexit=2
+        if ($i -eq 0)
+        {
+            $myexit=0
+        }
+        else
+        {
+            $myexit=2
+        }
+         break;
+    }
+    else
+    {
+        # We failed building. 
+        # Let us sleep for a bit.
+        # Then let the while loop do its thing and re-run.
+        sleep 1
+        if ($Verbose)
+        {
+            Write-Warning "`u{274C} Build failed. Retrying to see if sporadic..."
+        }
+    }
 }
 
-if ($LASTEXITCODE -ne 0)
+if ($myexit -eq 1)
 {
     if ($Verbose)
     {
         Write-Warning "`u{274C} Build failed. Log available at $errorLogFilePath"
     }
     exit 1
+}
+
+if ($myexit -eq 2)
+{
+    if ($Verbose)
+    {
+        Write-Warning "`u{274C} Build sporadically failed. Log available at $errorLogFilePath"
+    }
+    exit 2
 }
 
 Write-Verbose "Building Sample: $SampleName; Configuration: $Configuration; Platform: $Platform }"

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -145,6 +145,7 @@ $jresult = @{
     SolutionsExcluded    = 0
     SolutionsUnsupported = 0
     SolutionsFailed      = 0
+    SolutionsSporadic    = 0
     Results              = @()
     FailSet              = @()
     lock                 = [System.Threading.Mutex]::new($false)
@@ -174,6 +175,7 @@ Write-Output "S: Built and result was 'Succeeded'"
 Write-Output "E: Built and result was 'Excluded'"
 Write-Output "U: Built and result was 'Unsupported' (Platform and Configuration combination)"
 Write-Output "F: Built and result was 'Failed'"
+Write-Output "O: Built and result was 'Sporadic'"
 Write-Output ""
 Write-Output "Building all combinations..."
 
@@ -200,10 +202,12 @@ $SampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
         foreach ($platform in $Platforms) {
             $thisunsupported = 0
             $thisfailed = 0
+            $thissporadic = 0
             $thisexcluded = 0
             $thissucceeded = 0
             $thisresult = "Not run"
             $thisfailset = @()
+            $thissporadicset = @()
 
             if ($exclusionConfigurations.ContainsKey($sampleName) -and ($exclusionConfigurations[$sampleName].Split(';') | Where-Object { "$configuration|$platform" -like $_ })) {
                 # Verbose
@@ -222,8 +226,13 @@ $SampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
                     $thisfailed += 1
                     $thisresult = "Failed"
                 }
+                elseif ($LASTEXITCODE -eq 2) {
+                    $thissporadicset += "$sampleName $configuration|$platform"
+                    $thissporadic += 1
+                    $thisresult = "Sporadic"
+                }
                 else {
-                    # ($LASTEXITCODE -eq 2)
+                    # ($LASTEXITCODE -eq 3)
                     $thisunsupported += 1
                     $thisresult = "Unsupported"
                 }
@@ -237,7 +246,9 @@ $SampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
                 ($using:jresult).SolutionsExcluded += $thisexcluded
                 ($using:jresult).SolutionsUnsupported += $thisunsupported
                 ($using:jresult).SolutionsFailed += $thisfailed
+                ($using:jresult).SolutionsSporadic += $thissporadic
                 ($using:jresult).FailSet += $thisfailset
+                ($using:jresult).SporadicSet += $thissporadicset
                 $SolutionsTotal = $using:SolutionsTotal
                 $ThrottleLimit = $using:ThrottleLimit
                 $SolutionsBuilt = ($using:jresult).SolutionsBuilt
@@ -246,7 +257,7 @@ $SampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
                 $SolutionsPending = if ($SolutionsRemaining -ge $ThrottleLimit) { ($SolutionsRemaining - $ThrottleLimit) } else { 0 }
                 $SolutionsBuiltPercent = [Math]::Round(100 * ($SolutionsBuilt / $using:SolutionsTotal))
                 $TBRP = "T:" + ($SolutionsTotal) + "; B:" + (($using:jresult).SolutionsBuilt) + "; R:" + ($SolutionsRunning) + "; P:" + ($SolutionsPending)
-                $rstr = "S:" + (($using:jresult).SolutionsSucceeded) + "; E:" + (($using:jresult).SolutionsExcluded) + "; U:" + (($using:jresult).SolutionsUnsupported) + "; F:" + (($using:jresult).SolutionsFailed)
+                $rstr = "S:" + (($using:jresult).SolutionsSucceeded) + "; E:" + (($using:jresult).SolutionsExcluded) + "; U:" + (($using:jresult).SolutionsUnsupported) + "; F:" + (($using:jresult).SolutionsFailed) + "; O:" + (($using:jresult).SolutionsSporadic)
                 Write-Progress -Activity "Building combinations" -Status "$SolutionsBuilt of $using:SolutionsTotal combinations built ($SolutionsBuiltPercent%) | $TBRP | $rstr" -PercentComplete $SolutionsBuiltPercent
             }
             finally {
@@ -265,6 +276,8 @@ $SampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
 
 $sw.Stop()
 
+Write-Output ""
+
 if ($jresult.FailSet.Count -gt 0) {
     Write-Output "Some combinations were built with errors:"
     $jresult.FailSet = $jresult.FailSet | Sort-Object
@@ -274,10 +287,27 @@ if ($jresult.FailSet.Count -gt 0) {
         $failConfiguration = $Matches[2]
         $failPlatform = $Matches[3]
         Write-Output "Build errors in Sample $failName; Configuration: $failConfiguration; Platform: $failPlatform {"
-        Get-Content "$LogFilesDirectory\$failName.$failConfiguration.$failPlatform.err" | Write-Output
+        Get-Content "$LogFilesDirectory\$failName.$failConfiguration.$failPlatform.0.err" | Write-Output
         Write-Output "} $failedSample"
     }
     Write-Error "Some combinations were built with errors."
+    Write-Output ""
+}
+
+if ($jresult.SporadicSet.Count -gt 0) {
+    Write-Output "Some combinations were built with sporadic error:"
+    $jresult.SporadicSet = $jresult.SporadicSet | Sort-Object
+    foreach ($sporadicSample in $jresult.SporadicSet) {
+        $sporadicSample -match "^(.*) (\w*)\|(\w*)$" | Out-Null
+        $sporadicName = $Matches[1]
+        $sporadicConfiguration = $Matches[2]
+        $sporadicPlatform = $Matches[3]
+        Write-Output "Build sporadic errors in Sample $sporadicName; Configuration: $sporadicConfiguration; Platform: $sporadicPlatform {"
+        Get-Content "$LogFilesDirectory\$sporadicName.$sporadicConfiguration.$sporadicPlatform.0.err" | Write-Output
+        Write-Output "} $sporadicSample"
+    }
+    Write-Error "Some combinations were built with sporadic errors."
+    Write-Output ""
 }
 
 # Display timer statistics to host
@@ -288,9 +318,9 @@ $SolutionsSucceeded = $jresult.SolutionsSucceeded
 $SolutionsExcluded = $jresult.SolutionsExcluded
 $SolutionsUnsupported = $jresult.SolutionsUnsupported
 $SolutionsFailed = $jresult.SolutionsFailed
+$SolutionsSporadic = $jresult.SolutionsSporadic
 $Results = $jresult.Results
 
-Write-Output ""
 Write-Output "Built all combinations."
 Write-Output ""
 Write-Output "Elapsed time:         $min minutes, $seconds seconds."
@@ -303,6 +333,7 @@ Write-Output "Succeeded:            $SolutionsSucceeded"
 Write-Output "Excluded:             $SolutionsExcluded"
 Write-Output "Unsupported:          $SolutionsUnsupported"
 Write-Output "Failed:               $SolutionsFailed"
+Write-Output "Sporadic:             $SolutionsSporadic"
 Write-Output "Log files directory:  $LogFilesDirectory"
 Write-Output "Overview report:      $reportFilePath"
 Write-Output ""


### PR DESCRIPTION
This PR enable retry logic to catch sporadic failures.

We /can/ do this now because samples in general are building extremely cleanly and Failures are mostly unexpected events.  (If we expect lots of failures, then retrying would take a lot of time)

We /should/ do this now because we have dramatically extended the number of combinations each build takes and the number of branches we test against.  What is perhaps only happening in 1 of 5000 combinations will statistically happens once if you build 125 drivers across 4 flavors across 10 builds.

How it works: 
Specifically, whenever a build failure occur for a given (Driver, Configuration, Platform) combination (say, video/indirectdisplay, Debug, arm64) the tool will re-run up to three times. If all three builds results in failure, then the tool will mark the combination as indeed a failure.  If, however, on the second or third attempt, a successful build occurs, then the tool will mark the combination "Sporadic".

Note: We should still pursue "Sporadic" failures.  This PR helps isolate these from true Failures and allows other progress to me made.

Example:

(Assume 3 passing samples, 1 sample with a Failure, and 1 sample with a Sporadic failure)

```


>.\Build-AllSamples.ps1 -Samples '^tools"
...
Building all combinations...

Some combinations were built with errors:
Build errors in Sample tools.dv.samples.dv-faildriver-wdm.driver; Configuration: Debug; Platform: arm64 {
C:\wdstest\wdstest-tmp\ewdk\EWDK_ge_release_26063_240216-1326\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(456,5): error MSB8020: The build tools for WindowsKernelModeDriver12.0 (Platform Toolset = 'WindowsKernelModeDriver12.0') cannot be found. To build using the WindowsKernelModeDriver12.0 build tools, please install WindowsKernelModeDriver12.0 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution". [C:\wdstest\wdstest-tmp\git\develop\tools\dv\samples\DV-FailDriver-WDM\driver\defect_toastmon.vcxproj]
} tools.dv.samples.dv-faildriver-wdm.driver Debug|arm64
Write-Error: C:\wdstest\wdstest-tmp\git\develop\Build-AllSamples.ps1:71
Line |
  71 |  .\Build-SampleSet -SampleSet $sampleSet -Configurations $Configuratio …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Some combinations were built with errors.

Some combinations were built with sporadic error:
Build sporadic errors in Sample tools.sdv.samples.sdv-faildriver-wdm; Configuration: Debug; Platform: x64 {
C:\wdstest\wdstest-tmp\ewdk\EWDK_ge_release_26063_240216-1326\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(456,5): error MSB8020: The build tools for WindowsKernelModeDriver12.0 (Platform Toolset = 'WindowsKernelModeDriver12.0') cannot be found. To build using the WindowsKernelModeDriver12.0 build tools, please install WindowsKernelModeDriver12.0 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution". [C:\wdstest\wdstest-tmp\git\develop\tools\sdv\samples\SDV-FailDriver-WDM\driver\fail_driver1.vcxproj]
} tools.sdv.samples.sdv-faildriver-wdm Debug|x64
Write-Error: C:\wdstest\wdstest-tmp\git\develop\Build-AllSamples.ps1:71
Line |
  71 |  .\Build-SampleSet -SampleSet $sampleSet -Configurations $Configuratio …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Some combinations were built with sporadic errors.

Built all combinations.

Elapsed time:         0 minutes, 32 seconds.
Disk Remaining (GB):  182.792900085449
Samples:              5
Configurations:       2 (Debug Release)
Platforms:            2 (x64 arm64)
Combinations:         20
Succeeded:            18
Excluded:             0
Unsupported:          0
Failed:               1
Sporadic:             1
Log files directory:  C:\wdstest\wdstest-tmp\git\develop\_logs
Overview report:      C:\wdstest\wdstest-tmp\git\develop\_logs\_overview.htm

```