### PR TITLE
Fix TrEE Sample

### DIFF
--- a/TrEE/Miniport/SampleMiniport.c
+++ b/TrEE/Miniport/SampleMiniport.c
@@ -22,8 +22,13 @@ Environment:
 #include <wdmguid.h>
 #include <ntstrsafe.h>
 #include <TrustedRuntimeClx.h>
-//#include <ntefi.h>
-typedef UINT16          CHAR16;
+
+//
+// Header file <TrEEVariableService.h> requires prior definition of a CHAR16.
+// For now we need to define this in sample.
+//
+typedef UINT16 CHAR16;
+
 #include <TrEEVariableService.h>
 #include "sampleminiport.h"
 #include "..\inc\SampleSecureService.h"

--- a/TrEE/Miniport/SampleMiniport.c
+++ b/TrEE/Miniport/SampleMiniport.c
@@ -22,11 +22,12 @@ Environment:
 #include <wdmguid.h>
 #include <ntstrsafe.h>
 #include <TrustedRuntimeClx.h>
-#include <ntefi.h>
+//#include <ntefi.h>
+typedef UINT16          CHAR16;
 #include <TrEEVariableService.h>
 #include "sampleminiport.h"
-#include <SampleSecureService.h>
-#include <SampleOSService.h>
+#include "..\inc\SampleSecureService.h"
+#include "..\inc\SampleOSService.h"
 
 #define SDDL_SAMPLE_TEST2_SERVICE L"D:P(A;;FRFW;;;WD)(A;;FRFW;;;RC)(A;;FRFW;;;AC)"
 

--- a/TrEE/Miniport/TestService.c
+++ b/TrEE/Miniport/TestService.c
@@ -4,8 +4,8 @@
 #include <wdmguid.h>
 #include <TrustedRuntimeClx.h>
 #include "SampleMiniport.h"
-#include <SampleSecureService.h>
-#include <SampleOSService.h>
+#include "..\inc\SampleSecureService.h"
+#include "..\inc\SampleOSService.h"
 
 EVT_TR_CREATE_SECURE_SERVICE_CONTEXT TestServiceCreateSecureServiceContext;
 EVT_TR_DESTROY_SECURE_SERVICE_CONTEXT TestServiceDestroySecureServiceContext;
@@ -956,7 +956,7 @@ Test2ServiceTwiceReversed(
         goto TestServiceTwiceReversedEnd;
     }
 
-    TemporaryBuffer = ExAllocatePoolWithTag(PagedPool,
+    TemporaryBuffer = ExAllocatePool2(PagedPool,
                                             (SIZE_T)Request->InputBufferSize,
                                             'PMET');
 

--- a/TrEE/Miniport/TrEEMiniportSample.vcxproj
+++ b/TrEE/Miniport/TrEEMiniportSample.vcxproj
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -59,7 +67,23 @@
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>False</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>True</UseDebugLibraries>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <DriverType>KMDF</DriverType>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <ConfigurationType>Driver</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <TargetVersion>Windows10</TargetVersion>
     <UseDebugLibraries>True</UseDebugLibraries>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
@@ -96,7 +120,13 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -115,7 +145,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>TrEEMiniportSample</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <TargetName>TrEEMiniportSample</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>TrEEMiniportSample</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <TargetName>TrEEMiniportSample</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -175,7 +211,45 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
+      <ExceptionHandling>
+      </ExceptionHandling>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\treeclxstub.lib</AdditionalDependencies>
+    </Link>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
+      <ExceptionHandling>
+      </ExceptionHandling>
+    </ClCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\treeclxstub.lib</AdditionalDependencies>
+    </Link>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
     </ResourceCompile>

--- a/TrEE/TrEESample.sln
+++ b/TrEE/TrEESample.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
@@ -11,6 +11,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TrEEMiniportSample", "Minip
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Release|ARM64 = Release|ARM64
 		Debug|Arm = Debug|Arm
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
@@ -19,6 +21,14 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{420587AA-51DE-4966-B692-C428836BF8B2}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{420587AA-51DE-4966-B692-C428836BF8B2}.Debug|ARM64.Build.0 = Debug|ARM64
+		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Debug|ARM64.Build.0 = Debug|ARM64
+		{420587AA-51DE-4966-B692-C428836BF8B2}.Release|ARM64.ActiveCfg = Release|ARM64
+		{420587AA-51DE-4966-B692-C428836BF8B2}.Release|ARM64.Build.0 = Release|ARM64
+		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Release|ARM64.ActiveCfg = Release|ARM64
+		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Release|ARM64.Build.0 = Release|ARM64
 		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Debug|Arm.ActiveCfg = Debug|Arm
 		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Debug|Arm.Build.0 = Debug|Arm
 		{C1B22B3C-BE1A-40CE-82D0-8AE1628C297C}.Debug|Win32.ActiveCfg = Debug|Win32

--- a/exclusions.csv
+++ b/exclusions.csv
@@ -3,4 +3,3 @@ audio\acx\samples\audiocodec\driver,*,,22621,Only NI: error C1083: Cannot open i
 general\dchu\osrfx2_dchu_extension_loose,*|x64,,22621,Only NI: Only x64: Fails to build
 general\dchu\osrfx2_dchu_extension_tight,*|x64,,22621,Only NI: Only x64: Fails to build
 prm,*,,22621,Only NI: Not supported on NI.
-tree,*,,,Missing headers


### PR DESCRIPTION
The TrEE sample is literally the last sample on our .\exclusion.csv list.  Let's get it to build!!

This fix does narrow fixes to achieve exactly that and at same time adds arm64 as a target OS.

More specifically:
* This PR removes TrEE from the .\exclusion.csv list.
* This PR adds arm64 target support to vcxproj and sln file.
* This PR avoid including non-existing header file and instead adds typedef directly (see beneath).
* This PR includes project header files with "..\inc\foo.h" rather than <foo.h>.  I am not quite sure what the best way to write this is.  But at least this works :-) .
* This PR fixes a requirement to not use ExAllocatePoolWithTag

How tested:
* Built for all four flavors in:
* WDK 22621
* EWDK.ni_release_svc_prod1.22621.2428
* EWDK.ge_release.26063.1

Note: There is no suitable header file currently available that defines CHAR16:
```
C:\Program Files (x86)\Windows Kits\10\Include>findstr /s /m CHAR16 *
10.0.22621.0\km\treevariableservice.h
10.0.22621.0\um\icu.h
10.0.22621.0\um\icucommon.h
10.0.22621.0\um\mi.h
10.0.22621.0\um\WbemCli.h
10.0.22621.0\um\WbemCli.Idl
```