### PR TITLE
[WDI Sample] Refactoring Platform File IO ops to use WDM calls

### DIFF
--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -836,7 +836,7 @@ PlatformMapFile(
 
 VOID
 PlatformUnMapFile(
-	IN OUT	PRT_FILE_HANDLER	pFileHandler
+	IN OUT	u1Byte* contentBuffer
 	);
 
 VOID

--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -841,7 +841,7 @@ PlatformUnMapFile(
 
 VOID
 PlatformCloseFile(
-	IN OUT	PRT_FILE_HANDLER	pFileHandler
+	IN OUT	HANDLE* fileHandle
 	);
 
 RT_STATUS

--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -813,12 +813,12 @@ PlatformRequestPreAuthentication(
 
 RT_STATUS
 PlatformReadFile(
-	IN		PVOID		Adapter,
-	IN		ps1Byte		szFileName,
-	IN OUT	pu1Byte		pBufOfLines,
-	IN		s4Byte		nMaxNumLine,
-	IN		s4Byte		nMaxByteCntLine,
-	OUT		ps4Byte		pnNumLines	
+	IN		PVOID				Adapter,
+	IN		UNICODE_STRING		fileName,
+	IN OUT	pu1Byte				pBufOfLines,
+	IN		s4Byte				nMaxNumLine,
+	IN		s4Byte				nMaxByteCntLine,
+	OUT		ps4Byte				pnNumLinesRead
 	);
 
 RT_STATUS

--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -823,9 +823,8 @@ PlatformReadFile(
 
 RT_STATUS
 PlatformOpenFile(
-	IN		PVOID		Adapter,
-	IN		ps1Byte		szFileName,
-	IN OUT	PRT_FILE_HANDLER		pFileHandler
+	IN		UNICODE_STRING		fileName,
+	IN OUT	HANDLE*				fileHandle
 	);
 
 RT_STATUS

--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -829,7 +829,9 @@ PlatformOpenFile(
 
 RT_STATUS
 PlatformMapFile(
-	IN OUT	PRT_FILE_HANDLER	pFileHandler
+	IN OUT	HANDLE*	fileHandle,
+	OUT		u1Byte* contentBuffer,
+	OUT		s4Byte* contentBufferLength
 	);
 
 VOID

--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -846,10 +846,9 @@ PlatformCloseFile(
 
 RT_STATUS
 PlatformReadAndMapFile(
-	IN		PVOID		Adapter,
-	IN		ps1Byte		szFileName,
-	IN OUT	pu1Byte		pOutFile,
-	IN OUT	pu4Byte	UNALIGNED	pFileSize
+	IN		UNICODE_STRING		fileName,
+	OUT		u1Byte*				outFileBuffer,
+	OUT		u4Byte*				outFileBufferLength
 	);
 
 BOOLEAN

--- a/network/wlan/WDI/HEADER/PlatformDef.h
+++ b/network/wlan/WDI/HEADER/PlatformDef.h
@@ -814,7 +814,7 @@ PlatformRequestPreAuthentication(
 RT_STATUS
 PlatformReadFile(
 	IN		PVOID				Adapter,
-	IN		UNICODE_STRING		fileName,
+	IN		UNICODE_STRING*		fileName,
 	IN OUT	pu1Byte				pBufOfLines,
 	IN		s4Byte				nMaxNumLine,
 	IN		s4Byte				nMaxByteCntLine,
@@ -823,7 +823,7 @@ PlatformReadFile(
 
 RT_STATUS
 PlatformOpenFile(
-	IN		UNICODE_STRING		fileName,
+	IN		UNICODE_STRING*		fileName,
 	IN OUT	HANDLE*				fileHandle
 	);
 
@@ -846,7 +846,7 @@ PlatformCloseFile(
 
 RT_STATUS
 PlatformReadAndMapFile(
-	IN		UNICODE_STRING		fileName,
+	IN		UNICODE_STRING*		fileName,
 	OUT		u1Byte*				outFileBuffer,
 	OUT		u4Byte*				outFileBufferLength
 	);

--- a/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
@@ -414,6 +414,8 @@ PlatformMapFile(
 	else {
 		RT_TRACE(COMP_INIT, DBG_SERIOUS, ("PlatformReadFile(): failed to read file attributes!, ntStatus: %#X\n", ntStatus));
 	}
+
+	return rtStatus;
 }
 
 VOID
@@ -453,8 +455,8 @@ PlatformReadAndMapFile(
 	callStatus = PlatformOpenFile(fileName, &fileHandle);
 
 	if (callStatus == RT_STATUS_SUCCESS) {
-		u1Byte* fileBuffer;
-		u4Byte* fileBufferLength;
+		u1Byte* fileBuffer = NULL;
+		u4Byte* fileBufferLength = NULL;
 
 		callStatus = PlatformMapFile(&fileHandle, fileBuffer, fileBufferLength);
 

--- a/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
@@ -210,7 +210,7 @@ ParseFileBufToLines(
 RT_STATUS
 PlatformReadFile(
 	IN		PVOID				Adapter,
-	IN		UNICODE_STRING		fileName,
+	IN		UNICODE_STRING*		fileName,
 	IN OUT	pu1Byte				pBufOfLines,
 	IN		s4Byte				nMaxNumLine,
 	IN		s4Byte				nMaxByteCntLine,
@@ -233,7 +233,7 @@ PlatformReadFile(
 	// Initialize the object attributes of the file we want to open
 	InitializeObjectAttributes(
 		&objectAttributes,
-		&fileName,
+		fileName,
 		OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
 		NULL,	// RootDirectory 
 		NULL	// Default Security
@@ -313,7 +313,7 @@ PlatformReadFile(
 
 RT_STATUS
 PlatformOpenFile(
-	IN		UNICODE_STRING		fileName,
+	IN		UNICODE_STRING*		fileName,
 	IN OUT	HANDLE*				fileHandle
 	)
 {
@@ -325,7 +325,7 @@ PlatformOpenFile(
 	// Initialize the object attributes of the file we want to open
 	InitializeObjectAttributes(
 		&objectAttributes,
-		&fileName,
+		fileName,
 		OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
 		NULL,	// RootDirectory 
 		NULL	// Default Security
@@ -441,7 +441,7 @@ PlatformCloseFile(
 //
 RT_STATUS
 PlatformReadAndMapFile(
-	IN		UNICODE_STRING		fileName,
+	IN		UNICODE_STRING*		fileName,
 	OUT		u1Byte* outFileBuffer,
 	OUT		u4Byte* outFileBufferLength
 )

--- a/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
@@ -437,6 +437,48 @@ PlatformCloseFile(
 
 //
 //	Description:
+//		Open the file specifed and copy the file into an byte buffer, 
+//
+RT_STATUS
+PlatformReadAndMapFile(
+	IN		UNICODE_STRING		fileName,
+	OUT		u1Byte* outFileBuffer,
+	OUT		u4Byte* outFileBufferLength
+)
+{
+	RT_STATUS			rtStatus = RT_STATUS_FAILURE;
+	HANDLE				fileHandle;
+	RT_STATUS			callStatus;
+
+	callStatus = PlatformOpenFile(fileName, &fileHandle);
+
+	if (callStatus == RT_STATUS_SUCCESS) {
+		u1Byte* fileBuffer;
+		u4Byte* fileBufferLength;
+
+		callStatus = PlatformMapFile(&fileHandle, fileBuffer, fileBufferLength);
+
+		if (callStatus == RT_STATUS_SUCCESS) {
+			outFileBuffer = fileBuffer;
+			outFileBufferLength = fileBufferLength;
+			rtStatus = RT_STATUS_SUCCESS;
+		}
+		else {
+			RT_TRACE(COMP_INIT, DBG_SERIOUS, ("PlatformReadAndMapFile(): failed to map file!, rtStatus: %#X\n", callStatus));
+		}
+
+		PlatformCloseFile(fileHandle);
+	}
+	else {
+		RT_TRACE(COMP_INIT, DBG_SERIOUS, ("PlatformReadAndMapFile(): failed to open the file!, rtStatus: %#X\n", callStatus));
+	}
+
+	return rtStatus;
+}
+
+
+//
+//	Description:
 //		Indication for PHY power state changed.
 //	061013, by rcnjko.
 //
@@ -2773,47 +2815,6 @@ N6InitializeNative80211MIBs(
 
 	// PrivacyExemptionList
 	Adapter->pNdisCommon->PrivacyExemptionEntrieNum = 0;	
-}
-
-//
-//	Description:
-//		Open the file specifed and copy the file into an byte buffer, 
-//
-RT_STATUS
-PlatformReadAndMapFile(
-	IN		UNICODE_STRING		fileName,
-	OUT		u1Byte*				outFileBuffer,
-	OUT		u4Byte*				outFileBufferLength
-	)
-{
-	RT_STATUS			rtStatus = RT_STATUS_FAILURE;
-	HANDLE				fileHandle;
-	RT_STATUS			callStatus;
-
-	callStatus = PlatformOpenFile(fileName, &fileHandle);
-
-	if (callStatus == RT_STATUS_SUCCESS) {
-		u1Byte* fileBuffer;
-		u4Byte* fileBufferLength;
-
-		callStatus = PlatformMapFile(&fileHandle, fileBuffer, fileBufferLength);
-
-		if (callStatus == RT_STATUS_SUCCESS) {
-			outFileBuffer = fileBuffer;
-			outFileBufferLength = fileBufferLength;
-			rtStatus = RT_STATUS_SUCCESS;
-		}
-		else {
-			RT_TRACE(COMP_INIT, DBG_SERIOUS, ("PlatformReadAndMapFile(): failed to map file!, rtStatus: %#X\n", callStatus));
-		}
-
-		PlatformCloseFile(fileHandle);
-	}
-	else {
-		RT_TRACE(COMP_INIT, DBG_SERIOUS, ("PlatformReadAndMapFile(): failed to open the file!, rtStatus: %#X\n", callStatus));
-	}
-
-	return rtStatus;
 }
 
 

--- a/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
@@ -428,11 +428,11 @@ PlatformUnMapFile(
 
 VOID
 PlatformCloseFile(
-	IN OUT	PRT_FILE_HANDLER	pFileHandler
+	IN OUT	HANDLE* fileHandle
 	)
 {
 	// Relase the memory for mapping the file.
-	NdisCloseFile(pFileHandler->FileHandler);
+	ZwClose(fileHandle);
 }
 
 //

--- a/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
+++ b/network/wlan/WDI/PLATFORM/NDIS6/Ndis6Common.c
@@ -418,12 +418,13 @@ PlatformMapFile(
 
 VOID
 PlatformUnMapFile(
-	IN OUT	PRT_FILE_HANDLER	pFileHandler
+	IN OUT	u1Byte* contentBuffer
 	)
 {
 	// Relase the memory for mapping the file.
-	NdisUnmapFile(pFileHandler->FileHandler);
+	ExFreePool(contentBuffer);
 }
+
 
 VOID
 PlatformCloseFile(


### PR DESCRIPTION
### Why is this change being made?
The current implementation of the WDI driver example uses calls to deprecated NDIS functions: `NdisOpenFile`, `NdisMapFile`, `NdisUnmapFile`, `NdisCloseFile`. 
NDIS have deprecated the use of this functions and stick to only network-related operations which left this file operations not available for ARM64 architecture. Due to the current efforts to support ARM64, we need to refactor pieces of code within this driver to avoid the use of the deprecated NDIS calls such that we have a buildable driver for both x86_64 and ARM64. 

### What changed?
Refactored `PlatformReadFile`, `PlatformOpenFile`, `PlatformMapFile`, `PlatformUnMapFile`, `PlatformCloseFile` and `PlatformReadAndMapFile, to use the WDM calls for file operations and memory operations. This PR is the first step to enable the ARM64 support for this driver. 


