### PR TITLE
Support Occlusion Image in AvsCamera

### DIFF
--- a/avstream/avscamera/mft0/AvsCameraMFT0.rc
+++ b/avstream/avscamera/mft0/AvsCameraMFT0.rc
@@ -11,3 +11,8 @@
 
 #include "common.ver"
 
+#ifndef ID_OCCLUSION_IMAGE
+#define ID_OCCLUSION_IMAGE             200
+#endif
+
+ID_OCCLUSION_IMAGE     RCDATA     "TestImage.bmp"


### PR DESCRIPTION
Add support for 3rd Party Image Occlusion for an example for how to add an Image file to the system