### PR TITLE
Remove Boilerplate Text From Callout in Sample Keyboard Input Driver Doc

### DIFF
--- a/input/kbfiltr/README.md
+++ b/input/kbfiltr/README.md
@@ -107,4 +107,4 @@ On the target computer, in a Command Prompt window, enter **devmgmt** to open De
 To use the test application provided with the sample, it must be copied to the target computer manually. Save the kbftest.exe file from the folder where the build result is placed (for example, exe\\Debug). This file is copied somewhere on the target, possibly where the driver package files are located. The test application is the executed on the target computer in a Command Prompt using **kbftest** as the command.
 
 > [!TIP]
-> Optional information to help a user be more successfulTo avoid DLL dependencies for kbftext.exe, and the need to copy additional files, select the statically linked run-time library when building.
+> To avoid DLL dependencies for kbftext.exe, and the need to copy additional files, select the statically linked run-time library when building.


### PR DESCRIPTION
The current version of the `README.md` file for the keyboard filter driver sample erroneously includes what looks like boilerplate text in the callout at the bottom of the file. This text explains to the writer of the documentation what to include in the callout text, and should therefore have been removed when the actual content was added.

This change simply removes this change from the callout text.