### PR TITLE
CI Pipelines build with WDK Nuget Packages

### DIFF
--- a/.github/scripts/Install-Vsix.ps1
+++ b/.github/scripts/Install-Vsix.ps1
@@ -1,0 +1,68 @@
+<#
+
+.SYNOPSIS
+Checks WDK vsix version and downloads and installs as necessary.
+
+#>
+
+[CmdletBinding()]
+param(
+    [bool]$optimize = $false
+)
+
+$root = Get-Location
+
+# launch developer powershell (if necessary)
+if (-not $env:VSCMD_VER) {
+    Import-Module (Resolve-Path "$env:ProgramFiles\Microsoft Visual Studio\2022\*\Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+    Enter-VsDevShell -VsInstallPath (Resolve-Path "$env:ProgramFiles\Microsoft Visual Studio\2022\*")
+    cd $root
+}
+
+# source environment variables
+. .\Env-Vars.ps1
+
+$version = $env:SAMPLES_VSIX_VERSION
+$uri = $env:SAMPLES_VSIX_URI
+
+function PrintWdkVsix {
+    $installed = ls "${env:ProgramData}\Microsoft\VisualStudio\Packages\Microsoft.Windows.DriverKit,version=*" | Select -ExpandProperty Name
+    "WDK Vsix Version: $installed"
+}
+
+function TestWdkVsix {
+    Test-Path "${env:ProgramData}\Microsoft\VisualStudio\Packages\Microsoft.Windows.DriverKit,version=$version"
+}
+
+if ($optimize) {
+    "---> Downloading vsix and configuring build environment..."
+    Invoke-WebRequest -Uri "$uri" -OutFile wdk.zip
+    Expand-Archive ".\wdk.zip" .\
+    cp ".\`$MSBuild\*" (Resolve-Path "$env:ProgramFiles\Microsoft Visual Studio\2022\*\MSBuild\") -Recurse -Force
+    "<--- Finished"
+}
+else {
+    "Getting installed WDK vsix..."
+    PrintWdkVsix
+    "Checking the WDK.vsix version installed..."
+    if (-not (TestWdkVsix)) {
+        "The correct WDK vsix is not installed."
+        "Will attempt to download and install now..."
+        Invoke-WebRequest -Uri "$uri" -OutFile wdk.vsix
+        "Finished downloading."
+        "Starting install process. This will take some time to complete..."
+        Start-Process vsixinstaller -ArgumentList "/f /q /sp .\wdk.vsix" -wait
+        "The install process has finished."
+        "Checking the WDK.vsix version installed..."
+        if (TestWdkVsix) {
+            PrintWdkVsix
+            "The WDK vsix version is OK"
+        }
+        else {
+            "The WDK vsix install FAILED"
+            Write-Host "`u{274C} wdk vsix install had an issue"
+            Write-Error "the wdk vsix cannot be installed at this time"
+            exit 1
+        }
+    }
+}

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -32,31 +32,31 @@ jobs:
         language: [ 'cpp' ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        packs: microsoft/windows-drivers
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      - name: Install WDK VSIX
+        run: .\.github\scripts\Install-Vsix.ps1 -optimize:$true
 
-    - name: Retrieve and build all available solutions
-      run: |
-          .\Build-AllSamples.ps1 -Verbose -ThrottleLimit 1
-      env:
-        WDS_Configuration: Debug
-        WDS_Platform: x64
-        WDS_WipeOutputs: ${{ true }}
+      - name: Install Nuget Packages
+        run: nuget restore .\packages.config -PackagesDirectory .\packages\
 
-    - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
-    
-  
-      
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          packs: microsoft/windows-drivers
+
+      - name: Retrieve and build all available solutions
+        run: .\Build-AllSamples.ps1 -Verbose -ThrottleLimit 1
+        env:
+          WDS_Configuration: Debug
+          WDS_Platform: x64
+          WDS_WipeOutputs: ${{ true }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,8 +22,11 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+      - name: Install WDK VSIX
+        run: .\.github\scripts\Install-Vsix.ps1 -optimize:$true
+
+      - name: Install Nuget Packages
+        run: nuget restore .\packages.config -PackagesDirectory .\packages\
 
       - name: Get changed files
         id: get-changed-files
@@ -63,8 +66,7 @@ jobs:
           path: _logs
 
       - name: Join and generate global reports
-        run: |
-          .\.github\scripts\Join-CsvReports.ps1
+        run: .\.github\scripts\Join-CsvReports.ps1
 
       - name: Archive global overview build reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,14 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+      - name: Install WDK VSIX
+        run: .\.github\scripts\Install-Vsix.ps1 -optimize:$true
+
+      - name: Install Nuget Packages
+        run: nuget restore .\packages.config -PackagesDirectory .\packages\
 
       - name: Retrieve and build all available solutions
-        run: |
-          .\Build-AllSamples.ps1 -Verbose
+        run: .\Build-AllSamples.ps1 -Verbose
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
@@ -56,8 +58,7 @@ jobs:
           path: _logs
 
       - name: Join and generate global reports
-        run: |
-          .\.github\scripts\Join-CsvReports.ps1
+        run: .\.github\scripts\Join-CsvReports.ps1
 
       - name: Archive global overview build reports
         uses: actions/upload-artifact@v3

--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -9,6 +9,17 @@ param(
 )
 
 $root = Get-Location
+
+# launch developer powershell (if necessary)
+if (-not $env:VSCMD_VER) {
+    Import-Module (Resolve-Path "$env:ProgramFiles\Microsoft Visual Studio\2022\*\Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+    Enter-VsDevShell -VsInstallPath (Resolve-Path "$env:ProgramFiles\Microsoft Visual Studio\2022\*")
+    cd $root
+}
+
+# source environment variables
+. .\Env-Vars.ps1
+
 $ThrottleFactor = 5
 $LogicalProcessors = (Get-CIMInstance -Class 'CIM_Processor' -Verbose:$false).NumberOfLogicalProcessors
 
@@ -51,21 +62,20 @@ finally {
 $build_environment=""
 $build_number=0
 #
-# WDK NuGet will require presence of a folder 'packages'
+# In Github we build using Nuget only and source version from repo .\Env-Vars.ps1.
 #
-#
-# Hack: In GitHub we do not have an environment variable where we can see WDK build number, so we have it hard coded.
-#
-if (-not $env:GITHUB_REPOSITORY -eq '') {
+if ($env:GITHUB_REPOSITORY) {
     $build_environment="GitHub"
-    $build_number=22621
+    $build_number=$env:SAMPLES_BUILD_NUMBER
 }
+#
+# WDK NuGet will require presence of a folder 'packages'. The version is sourced from repo .\Env-Vars.ps1.
 #
 # Hack: If user has hydrated nuget packages, then use those. That will be indicated by presence of a folder named .\packages.
 #
 elseif(Test-Path(".\packages")) {
     $build_environment=("NuGet")
-    $build_number=26100
+    $build_number=$env:SAMPLES_BUILD_NUMBER
 }
 #
 # EWDK sets environment variable BuildLab.  For example 'ni_release_svc_prod1.22621.2428'.

--- a/Env-Vars.ps1
+++ b/Env-Vars.ps1
@@ -1,0 +1,9 @@
+# Environment variables for script sourcing.
+# Note: When a new WDK ships the following need to be updated: 
+#       1. Environment variables in .\Env-Vars.ps1 (this script)
+#       2. Nuget package versions in .\packages.config 
+#       3. Nuget package versions in .\Directory.Build.props
+#       4. SDK and WDK versions and WDK vsix link in .\configuration.dsc.yaml
+$env:SAMPLES_VSIX_VERSION = "10.0.26100.0"
+$env:SAMPLES_VSIX_URI = "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/DriverDeveloperKits-WDK/vsextensions/WDKVsix/10.0.26100.0/vspackage?targetPlatform=5e3e564c-03bb-4499-8ae5-b2b35e9a86dc"
+$env:SAMPLES_BUILD_NUMBER = "26100"


### PR DESCRIPTION
With the WDK now supporting Nuget packages for ease of install it is beneficial to have the CI pipeline also utilize this ability. This will allow easier and faster integration when new WDK versions are published without relying on the runner images to be updated.

- Adds Nuget package capability to the CI pipeline.
- Adds installation of WDK vsix directly into the CI pipeline.
- Updates environment variables for ease of incrementing component versions.

### Pipeline Time Metrics
**BuildAll** (push and pull_request)
Without Vsix Install: ~08m 59s
With Vsix Install: ~38m 59s (optimized ~8m)

**CodeQL** (push and pull_request)
Without Vsix Install: ~1h 1m 43s
With Vsix Install: ~1h 34m 31s (optimized ~1h 16m 2s)

**Average** WDK Vsix Install Time
~21m (optimized ~15s)

**Average** WDK Nuget Restore
~1m 30s