### PR TITLE
Replace IoCreateDevice to IoCreateDeviceSecure.

### DIFF
--- a/network/ndis/ndisprot/6x/sys/ntdisp.c
+++ b/network/ndis/ndisprot/6x/sys/ntdisp.c
@@ -89,12 +89,14 @@ Return Value:
         //
         RtlInitUnicodeString(&ntDeviceName, NT_DEVICE_NAME);
 
-        status = IoCreateDevice (pDriverObject,
+        status = IoCreateDeviceSecure (pDriverObject,
                                  0,
                                  &ntDeviceName,
                                  FILE_DEVICE_NETWORK,
                                  FILE_DEVICE_SECURE_OPEN,
                                  FALSE,
+                                 &SDDL_DEVOBJ_SYS_ALL_ADM_ALL,
+                                 NULL,
                                  &deviceObject);
     
         if (!NT_SUCCESS (status))


### PR DESCRIPTION
Replace IoCreateDevice to IoCreateDeviceSecure.

Documentation of IoCreateDevice mentions as follows. This sample is creating a named device object, and it is not specified security descriptor in the INF file. Thus, it should use IoCreateDeviceSecure instead of IoCreateDevice.

[IoCreateDevice function (wdm.h)](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-iocreatedevice#remarks)
> IoCreateDevice can only be used to create an unnamed device object, or a named device object for which a security descriptor is set by an INF file. Otherwise, drivers must use IoCreateDeviceSecure to create named device objects.

