### PR TITLE
[serial/VirtualSerial2] Use helper function ReadNoFence to read lineControlRegister to avoid C26837

### DIFF
--- a/serial/VirtualSerial2/queue.c
+++ b/serial/VirtualSerial2/queue.c
@@ -717,7 +717,7 @@ QueueProcessGetLineControl(
     //
     // Take a snapshot of the line control register variable
     //
-    lineControlSnapshot = *lineControlRegister;
+    lineControlSnapshot = ReadNoFence((LONG *)lineControlRegister);
 
     //
     // Decode the word length
@@ -801,7 +801,7 @@ QueueProcessSetLineControl(
     NTSTATUS                status;
     PDEVICE_CONTEXT         deviceContext;
     SERIAL_LINE_CONTROL     lineControl = {0};
-    volatile ULONG*         lineControlRegister;
+    ULONG                   *lineControlRegister;
     UCHAR                   lineControlData = 0;
     UCHAR                   lineControlStop = 0;
     UCHAR                   lineControlParity = 0;
@@ -946,7 +946,7 @@ QueueProcessSetLineControl(
 #endif
         }
 
-        lineControlSnapshot = *lineControlRegister;
+        lineControlSnapshot = ReadNoFence((LONG *)lineControlRegister);
 
         lineControlNew = (lineControlSnapshot & SERIAL_LCR_BREAK) |
                         (lineControlData | lineControlParity | lineControlStop);

--- a/serial/VirtualSerial2/queue.c
+++ b/serial/VirtualSerial2/queue.c
@@ -801,7 +801,7 @@ QueueProcessSetLineControl(
     NTSTATUS                status;
     PDEVICE_CONTEXT         deviceContext;
     SERIAL_LINE_CONTROL     lineControl = {0};
-    ULONG                   *lineControlRegister;
+    volatile ULONG*         lineControlRegister;
     UCHAR                   lineControlData = 0;
     UCHAR                   lineControlStop = 0;
     UCHAR                   lineControlParity = 0;


### PR DESCRIPTION
Warning C26837
https://learn.microsoft.com/en-us/cpp/code-quality/c26837?view=msvc-170