### PR TITLE
Fixes and updates for StorageCore driver sample components

### DIFF
--- a/storage/class/classpnp/src/class.c
+++ b/storage/class/classpnp/src/class.c
@@ -3740,7 +3740,7 @@ ClassIoComplete(
     PSCSI_REQUEST_BLOCK srb = Context;
     PFUNCTIONAL_DEVICE_EXTENSION fdoExtension = Fdo->DeviceExtension;
     PCLASS_PRIVATE_FDO_DATA fdoData = fdoExtension->PrivateFdoData;
-    NTSTATUS status;
+    NTSTATUS status = STATUS_SUCCESS;
     BOOLEAN retry;
     BOOLEAN callStartNextPacket;
     ULONG srbFlags;
@@ -6055,7 +6055,7 @@ __ClassInterpretSenseInfo_ProcessingInvalidSenseBuffer:
                         logErrorInternal = FALSE;
                         logError = FALSE;
                     } else if (cdbOpcode == SCSIOP_MODE_SENSE10) {
-                        USHORT allocationLength;
+                        USHORT allocationLength = 0;
                         REVERSE_BYTES_SHORT(&(cdb->MODE_SENSE10.AllocationLength), &allocationLength);
                         if (SrbGetDataTransferLength(Srb) <= allocationLength) {
                             *Status = STATUS_SUCCESS;
@@ -6063,7 +6063,7 @@ __ClassInterpretSenseInfo_ProcessingInvalidSenseBuffer:
                             logError = FALSE;
                         }
                     } else if (ClasspIsReceiveTokenInformation(cdb)) {
-                        ULONG allocationLength;
+                        ULONG allocationLength = 0;
                         REVERSE_BYTES(&(cdb->RECEIVE_TOKEN_INFORMATION.AllocationLength), &allocationLength);
                         if (SrbGetDataTransferLength(Srb) <= allocationLength) {
                             *Status = STATUS_SUCCESS;

--- a/storage/class/classpnp/src/obsolete.c
+++ b/storage/class/classpnp/src/obsolete.c
@@ -119,7 +119,7 @@ ClassIoCompleteAssociated(
     PIRP originalIrp = Irp->AssociatedIrp.MasterIrp;
     LONG irpCount;
 
-    NTSTATUS status;
+    NTSTATUS status = STATUS_SUCCESS;
     BOOLEAN retry;
 
     TracePrint((TRACE_LEVEL_WARNING, TRACE_FLAG_GENERAL, "ClassIoCompleteAssociated is OBSOLETE !"));
@@ -390,8 +390,8 @@ RetryRequest(
         //
 
         NT_ASSERT(SrbGetDataBuffer(srbHeader) == MmGetMdlVirtualAddress(Irp->MdlAddress));
-    _Analysis_assume_(Irp->MdlAddress->ByteCount <= dataTransferLength);
-        transferByteCount = Irp->MdlAddress->ByteCount;
+    _Analysis_assume_(MmGetMdlByteCount(Irp->MdlAddress) <= dataTransferLength);
+        transferByteCount = MmGetMdlByteCount(Irp->MdlAddress);
 
     } else {
 

--- a/storage/class/disk/src/disk.c
+++ b/storage/class/disk/src/disk.c
@@ -707,7 +707,7 @@ Return Value:
         mediaTypes->MediaInfoCount = 1;
 
         mediaInfo->DeviceSpecific.DiskInfo.Cylinders.QuadPart   = fdoExtension->DiskGeometry.Cylinders.QuadPart;
-        mediaInfo->DeviceSpecific.DiskInfo.MediaType            = FixedMedia;
+        mediaInfo->DeviceSpecific.DiskInfo.MediaType            = (STORAGE_MEDIA_TYPE)FixedMedia;
         mediaInfo->DeviceSpecific.DiskInfo.TracksPerCylinder    = fdoExtension->DiskGeometry.TracksPerCylinder;
         mediaInfo->DeviceSpecific.DiskInfo.SectorsPerTrack      = fdoExtension->DiskGeometry.SectorsPerTrack;
         mediaInfo->DeviceSpecific.DiskInfo.BytesPerSector       = fdoExtension->DiskGeometry.BytesPerSector;
@@ -899,7 +899,7 @@ SkipTable:
             mediaTypes->MediaInfoCount = 1;
 
             mediaInfo->DeviceSpecific.RemovableDiskInfo.Cylinders.QuadPart   = fdoExtension->DiskGeometry.Cylinders.QuadPart;
-            mediaInfo->DeviceSpecific.RemovableDiskInfo.MediaType            = RemovableMedia;
+            mediaInfo->DeviceSpecific.RemovableDiskInfo.MediaType            = (STORAGE_MEDIA_TYPE)RemovableMedia;
             mediaInfo->DeviceSpecific.RemovableDiskInfo.TracksPerCylinder    = fdoExtension->DiskGeometry.TracksPerCylinder;
             mediaInfo->DeviceSpecific.RemovableDiskInfo.SectorsPerTrack      = fdoExtension->DiskGeometry.SectorsPerTrack;
             mediaInfo->DeviceSpecific.RemovableDiskInfo.BytesPerSector       = fdoExtension->DiskGeometry.BytesPerSector;

--- a/storage/class/disk/src/diskwmi.c
+++ b/storage/class/disk/src/diskwmi.c
@@ -1739,7 +1739,7 @@ DiskInfoExceptionComplete(
                 //
                 // Reset byte count of transfer in SRB Extension.
                 //
-                srbEx->DataTransferLength = Irp->MdlAddress->ByteCount;
+                srbEx->DataTransferLength = MmGetMdlByteCount(Irp->MdlAddress);
 
                 //
                 // Zero SRB statuses.
@@ -1768,7 +1768,7 @@ DiskInfoExceptionComplete(
                 //
                 // Reset byte count of transfer in SRB Extension.
                 //
-                srb->DataTransferLength = Irp->MdlAddress->ByteCount;
+                srb->DataTransferLength = MmGetMdlByteCount(Irp->MdlAddress);
 
                 //
                 // Zero SRB statuses.

--- a/storage/miniports/lsi_u3/src/lsi_u3.inf
+++ b/storage/miniports/lsi_u3/src/lsi_u3.inf
@@ -37,8 +37,9 @@ lsi_u3.sys = 1
 DefaultDestDir = 12 ; DIRID_DRIVERS
 
 [Manufacturer]
-%LSI%=LSI,NTamd64,NTia64,NTarm64
+%LSI%=LSI,NT$ARCH$
 
+;One of the following sections will be used based on $ARCH$. Template INF.
 [LSI.NTamd64]
 %DevDesc1% = LSI_U3_Inst, PCI\VEN_1000&DEV_0020
 %DevDesc2% = LSI_U3_Inst, PCI\VEN_1000&DEV_0021

--- a/storage/miniports/lsi_u3/src/lsi_u3.inf
+++ b/storage/miniports/lsi_u3/src/lsi_u3.inf
@@ -36,6 +36,7 @@ lsi_u3.sys = 1
 [DestinationDirs]
 DefaultDestDir = 12 ; DIRID_DRIVERS
 
+; Use NT$ARCH$ for platform-specific stamping via Stampinf
 [Manufacturer]
 %LSI%=LSI,NT$ARCH$
 


### PR DESCRIPTION
Fix 1: cpp/drivers/opaque-mdl-use codeql query. Fix for opaque MDL field accesses in classpnp and disk. Use recommended API.
Fix 2: cpp/uninitialized-local codeql query. Fix for uninitialized variables during access.
Fxi 3: cpp/conditionally-uninitialized-variable codeql rule. Initialize variables that are passed by reference to a function if the status of the function is not checked.
Fix 4: Update INF file for lsi_u3 driver to use $ARCH$ for platform-specific stamping via Stampinf.