### PR TITLE
Fix the wdk version in EWDK

### DIFF
--- a/Build-SampleSet.ps1
+++ b/Build-SampleSet.ps1
@@ -104,19 +104,20 @@ else {
     exit 1
 }
 #
-# Get the WDK extension version from installed packages
-$wdk_extension_ver = Get-ChildItem "${env:ProgramData}\Microsoft\VisualStudio\Packages\Microsoft.Windows.DriverKit,version=*" | Select-Object -ExpandProperty Name
-$wdk_extension_ver = ([regex]'(\d+\.)(\d+\.)(\d+\.)(\d+)').Matches($wdk_extension_ver).Value
-if (-not $wdk_extension_ver) {
-    # Be lenient with EWDK builds that do not include the package information
-    if ($build_environment -match '^EWDK') {
-        $wdk_extension_ver = "(package not found)"
-    }
-    else {
+
+# Be lenient with EWDK builds that do not include the package information
+if ($build_environment -match '^EWDK') {
+    $wdk_extension_ver = "(package is not included for EWDK builds)"
+} else {
+    # Get the WDK extension version from installed packages
+    $wdk_extension_ver = Get-ChildItem "${env:ProgramData}\Microsoft\VisualStudio\Packages\Microsoft.Windows.DriverKit,version=*" -ErrorAction SilentlyContinue
+    if (-not $wdk_extension_ver) {
         Write-Error "No version of the WDK Visual Studio Extension could be found. The WDK Extension is not installed."
         exit 1
     }
+    $wdk_extension_ver = [regex]::Match($wdk_extension_ver.Name, '(\d+\.){3}\d+').Value
 }
+
 #
 #
 # InfVerif_AdditionalOptions


### PR DESCRIPTION
Build-sample set was printing an error message when trying to find the WDK version while using the EWDK.

# Behavior without changes

<img width="863" height="293" alt="image" src="https://github.com/user-attachments/assets/86b59a67-8709-4bd7-a3c4-2a94a4a1dbad" />


# Behavior with changes

<img width="858" height="226" alt="image" src="https://github.com/user-attachments/assets/8aebe268-2392-46c2-a930-2f91a3e0ca26" />

