### PR TITLE
Update Driver Sample With Correct Enum

### DIFF
--- a/serial/serial/ioctl.c
+++ b/serial/serial/ioctl.c
@@ -2032,7 +2032,7 @@ Return Value:
         //
         // Override the default settings from allow user control to do not allow.
         //
-        wakeSettings.UserControlOfWakeSettings = IdleDoNotAllowUserControl;
+        wakeSettings.UserControlOfWakeSettings = WakeDoNotAllowUserControl;
         status = WdfDeviceAssignSxWakeSettings(pDevExt->WdfDevice, &wakeSettings);
         if (!NT_SUCCESS(status)) {
             SerialDbgPrintEx(TRACE_LEVEL_ERROR, DBG_PNP, "WdfDeviceAssignSxWakeSettings failed %x \n", status);
@@ -2050,7 +2050,7 @@ Return Value:
        // Override the default settings.
        //
        wakeSettings.Enabled = WdfFalse; // Disables wait-wake
-       wakeSettings.UserControlOfWakeSettings = IdleDoNotAllowUserControl;
+       wakeSettings.UserControlOfWakeSettings = WakeDoNotAllowUserControl;
        status = WdfDeviceAssignSxWakeSettings(pDevExt->WdfDevice, &wakeSettings);
        if (!NT_SUCCESS(status)) {
            SerialDbgPrintEx(TRACE_LEVEL_ERROR, DBG_PNP, "WdfDeviceAssignSxWakeSettings failed %x \n", status);


### PR DESCRIPTION
The current driver sample under Serial/Ioctl.c calls the incorrect enum resulting in errors when building the code.  
 wakeSettings.UserControlOfWakeSettings is of type WDF_POWER_POLICY_SX_WAKE_USER_CONTROL and should be set to WakeDoNotAllowUserControl not IdleDoNotAllowUserControl.

After updating, the build was complete with no errors. 
<img width="285" height="118" alt="image" src="https://github.com/user-attachments/assets/b6befffb-98d0-4fda-ba8c-fb021c07e1d4" />
