### PR TITLE
Updated Sample Driver Enum

### DIFF
--- a/serial/serial/ioctl.c
+++ b/serial/serial/ioctl.c
@@ -2032,7 +2032,7 @@ Return Value:
         //
         // Override the default settings from allow user control to do not allow.
         //
-        wakeSettings.UserControlOfWakeSettings = IdleDoNotAllowUserControl;
+        wakeSettings.UserControlOfWakeSettings = WakeDoNotAllowUserControl;
         status = WdfDeviceAssignSxWakeSettings(pDevExt->WdfDevice, &wakeSettings);
         if (!NT_SUCCESS(status)) {
             SerialDbgPrintEx(TRACE_LEVEL_ERROR, DBG_PNP, "WdfDeviceAssignSxWakeSettings failed %x \n", status);
@@ -2050,7 +2050,7 @@ Return Value:
        // Override the default settings.
        //
        wakeSettings.Enabled = WdfFalse; // Disables wait-wake
-       wakeSettings.UserControlOfWakeSettings = IdleDoNotAllowUserControl;
+       wakeSettings.UserControlOfWakeSettings = WakeDoNotAllowUserControl;
        status = WdfDeviceAssignSxWakeSettings(pDevExt->WdfDevice, &wakeSettings);
        if (!NT_SUCCESS(status)) {
            SerialDbgPrintEx(TRACE_LEVEL_ERROR, DBG_PNP, "WdfDeviceAssignSxWakeSettings failed %x \n", status);


### PR DESCRIPTION
Currently the Serial sample driver sets wakeSettings.UserControlOfWakeSettings to an incompatible enum type. The value was updated to be WakeDoNotAllowUserControl so that the driver can build correctly instead.

<img width="254" height="117" alt="Screenshot 2025-07-31 131820" src="https://github.com/user-attachments/assets/e78ba817-4519-4b55-898f-bcd95603e098" />
