### PR TITLE
devcon: In MSG_FAILURE, show the cmd name

### DIFF
--- a/setup/devcon/msg.mc
+++ b/setup/devcon/msg.mc
@@ -12,7 +12,7 @@ For more information, type: %1 help
 .
 MessageId=60001 SymbolicName=MSG_FAILURE
 Language=English
-%1 failed.
+%1: command %2 failed
 .
 MessageId=60002 SymbolicName=MSG_COMMAND_USAGE
 Language=English


### PR DESCRIPTION
It's not very useful, but we might as well show what command failed, instead of simply "devcon failed." as now.  This now shows:

  devcon: command disable failed