### PR TITLE
Disable tag-codeowner-on-issue workflow

### DIFF
--- a/.github/workflows/tag-codeowner-on-issue.yml
+++ b/.github/workflows/tag-codeowner-on-issue.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   tag-codeowner:
+    if: false # Disabled - workflow intentionally turned off
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Added 'if: false' to the job to prevent it from running while preserving the code.