### PR TITLE
ci: update Code-Scanning workflow to use Build-Samples.ps1

### DIFF
--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -66,7 +66,7 @@ jobs:
           WDS_Platform: x64
           WDS_WipeOutputs: ${{ true }}
       - if: github.event_name == 'push'
-        run: .\Build-AllSamples.ps1 -Verbose -ThrottleLimit 1
+        run: .\Build-Samples.ps1 -Verbose -ThrottleLimit 1
         env:
           WDS_Configuration: Debug
           WDS_Platform: x64


### PR DESCRIPTION
Build-AllSamples.ps1 was removed in favor of Build-Samples.ps1.