### PR TITLE
Optimize CodeQL scanning with sharding and job separation

### DIFF
--- a/.github/scripts/Build-ChangedSamples.ps1
+++ b/.github/scripts/Build-ChangedSamples.ps1
@@ -22,7 +22,7 @@ foreach ($file in $ChangedFiles) {
     $filename = Split-Path $file -Leaf
 
     # Files that can affect how every sample is built should trigger a full build
-    if ($filename -eq "Build-Samples.ps1" -or $filename -eq "exclusions.csv" -or $filename -eq "Directory.Build.props" -or $filename -eq "packages.config") {
+    if ($filename -eq "Build-Samples.ps1" -or $filename -eq "Get-NtTargetVersions.ps1" -or $filename -eq "exclusions.csv" -or $filename -eq "Directory.Build.props" -or $filename -eq "packages.config") {
         $buildAll = $true
     }
     if ($dir -like "$root\.github\scripts" -or $dir -like "$root\.github\scripts\*") {

--- a/.github/scripts/Join-CsvReports.ps1
+++ b/.github/scripts/Join-CsvReports.ps1
@@ -1,35 +1,209 @@
-$logsPath = Join-Path (Get-Location).Path "_logs"
-$reportFileName = '_overview.all'
-$idProperty = 'Sample'
-$results = $null
+<#
+.SYNOPSIS
+    Joins the per-job Build-Samples CSV reports (one per _NT_TARGET_VERSION x configuration x
+    platform) into a single overview, and writes an easy-to-scan summary to the GitHub Actions
+    run page ($GITHUB_STEP_SUMMARY).
 
-Get-ChildItem -Path $logsPath -Filter '*.csv' | ForEach-Object {
-    $csv = Import-Csv -Path $_
-    if ($results -eq $null) {
-        $results = $csv
-    }
-    else {
-        $results = $csv | ForEach-Object {
-            $id = $_.$idProperty
-            $match = $results | Where-Object { $_.$idProperty -eq $id }
-            if ($match) {
-                $properties = $_ | Get-Member -MemberType NoteProperty | Where-Object { $_.Name -ne $idProperty } | Select-Object -ExpandProperty Name
-                $newObject = New-Object PSObject
-                # Add ID property separately to ensure it appears first
-                $newObject | Add-Member -MemberType NoteProperty -Name $idProperty -Value $_.$idProperty
-                foreach ($property in $properties) {
-                    $newObject | Add-Member -MemberType NoteProperty -Name $property -Value $_.$property
-                }
-                foreach ($property in ($match | Get-Member -MemberType NoteProperty | Where-Object { $_.Name -ne $idProperty } | Select-Object -ExpandProperty Name)) {
-                    if ($properties -notcontains $property) {
-                        $newObject | Add-Member -MemberType NoteProperty -Name $property -Value $match.$property
-                    }
-                }
-                $newObject
+.DESCRIPTION
+    Each build job uploads a "_logs" folder containing a report named
+        _overview.<ntTag>.<configuration>.<platform>.csv
+    with columns: Sample, <Configuration|Platform>  (one combination per file). This script:
+      * parses the _NT_TARGET_VERSION tag and combination from every report,
+      * collapses each sample's combinations into one status per version,
+      * writes _overview.all.csv / _overview.all.htm (a colour-coded sample x version matrix), and
+      * appends a Markdown summary (per-version totals + a failures table) to $GITHUB_STEP_SUMMARY
+        so failures are obvious from the run page without opening any logs.
+
+    The older 2-part name (_overview.<configuration>.<platform>.csv, no version) is still
+    understood and bucketed under the "latest" column.
+#>
+
+$logsPath       = Join-Path (Get-Location).Path "_logs"
+$reportFileName = '_overview.all'
+
+if (-not (Test-Path $logsPath)) {
+    Write-Warning "No _logs directory found at $logsPath - nothing to report."
+    return
+}
+
+# --- Friendly labels for the known _NT_TARGET_VERSION build tags --------------
+$ntLabel = @{
+    '28000' = 'latest'; '26100' = '24H2'; '22621' = '22H2'; '22000' = '21H2'
+    '20348' = 'Server 2022'; '19041' = '2004'; '18362' = '1903'; '17763' = '1809'
+}
+
+# --- Load every per-job CSV ---------------------------------------------------
+# data[sample][tag][combo] = status
+$data       = @{}
+$allSamples = [System.Collections.Generic.SortedSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$tagSet     = [System.Collections.Generic.HashSet[string]]::new()
+
+Get-ChildItem -Path $logsPath -Filter '_overview.*.csv' |
+    Where-Object { $_.Name -notlike '_overview.all.*' } |
+    ForEach-Object {
+        # _overview.<tag>.<config>.<platform>  ->  drop _overview; last two are config/platform.
+        $parts = [IO.Path]::GetFileNameWithoutExtension($_.Name).Split('.')
+        $parts = $parts[1..($parts.Count - 1)]          # drop the leading "_overview"
+        if ($parts.Count -ge 3) { $tag = ($parts[0..($parts.Count - 3)] -join '.') }
+        else                    { $tag = 'latest' }
+        [void]$tagSet.Add($tag)
+
+        Import-Csv -Path $_.FullName | ForEach-Object {
+            $sample = $_.Sample
+            if (-not $sample) { return }
+            [void]$allSamples.Add($sample)
+            if (-not $data.ContainsKey($sample)) { $data[$sample] = @{} }
+            if (-not $data[$sample].ContainsKey($tag)) { $data[$sample][$tag] = @{} }
+            foreach ($col in ($_.PSObject.Properties.Name | Where-Object { $_ -ne 'Sample' })) {
+                $data[$sample][$tag][$col] = "$($_.$col)".Trim()
             }
         }
     }
+
+if ($tagSet.Count -eq 0) {
+    Write-Warning "No per-job '_overview.*.csv' reports were found in $logsPath."
+    return
 }
 
-$results | ConvertTo-Csv | Out-File (Join-Path $logsPath "$reportFileName.csv")
-$results | ConvertTo-Html -Title "Overview" | Out-File (Join-Path $logsPath "$reportFileName.htm")
+# Order versions newest-first (numeric tags descending; non-numeric last)
+$tags = $tagSet | Sort-Object @{ Expression = { if ($_ -match '^\d+$') { [int]$_ } else { 0 } }; Descending = $true }, @{ Expression = { $_ } }
+
+function Get-Status {
+    # Collapse one sample/version's combinations into a single status object.
+    param([hashtable]$Combos)
+    $c = @{ Succeeded = 0; Failed = 0; Sporadic = 0; Unsupported = 0; Excluded = 0 }
+    $details = @()
+    if ($Combos) {
+        foreach ($k in ($Combos.Keys | Sort-Object)) {
+            switch ($Combos[$k]) {
+                'Succeeded' { $c.Succeeded++ } 'Failed' { $c.Failed++ } 'Sporadic' { $c.Sporadic++ }
+                'Unsupported' { $c.Unsupported++ } 'Excluded' { $c.Excluded++ }
+            }
+            $details += "$k = $($Combos[$k])"
+        }
+    }
+    $buildable = $c.Succeeded + $c.Failed + $c.Sporadic
+    if (-not $Combos -or $Combos.Count -eq 0) { $label = 'n/a'; $klass = 'na' }
+    elseif ($buildable -eq 0) { $label = '--'; $klass = 'na' }
+    elseif ($c.Failed -eq 0 -and $c.Sporadic -eq 0) { $label = "PASS ($($c.Succeeded)/$buildable)"; $klass = 'pass' }
+    elseif ($c.Failed -eq 0) { $label = "PASS* ($($c.Succeeded + $c.Sporadic)/$buildable)"; $klass = 'flaky' }
+    elseif ($c.Failed -eq $buildable) { $label = "FAIL ($($c.Failed)/$buildable)"; $klass = 'fail' }
+    else { $label = "PARTIAL ($($c.Failed) failed / $buildable)"; $klass = 'partial' }
+    [pscustomobject]@{ Label = $label; Class = $klass; Tooltip = ($details -join ' | '); Counts = $c; Buildable = $buildable }
+}
+
+# --- Build per-version totals + the matrix ------------------------------------
+$totals = @{}; foreach ($t in $tags) { $totals[$t] = [pscustomobject]@{ S = 0; F = 0; O = 0; U = 0; E = 0; pass = 0; flaky = 0; partial = 0; fail = 0; na = 0 } }
+$failuresList = [System.Collections.ArrayList]::new()
+$csvRows = @()
+$bodyRows = New-Object System.Text.StringBuilder
+
+foreach ($sample in $allSamples) {
+    $csvRow = [ordered]@{ Sample = $sample }
+    $cells = ''
+    foreach ($t in $tags) {
+        $combos = $null
+        if ($data[$sample].ContainsKey($t)) { $combos = $data[$sample][$t] }
+        $st = Get-Status -Combos $combos
+        $tt = $totals[$t]
+        $tt.S += $st.Counts.Succeeded; $tt.F += $st.Counts.Failed; $tt.O += $st.Counts.Sporadic
+        $tt.U += $st.Counts.Unsupported; $tt.E += $st.Counts.Excluded
+        switch ($st.Class) { 'pass' { $tt.pass++ } 'flaky' { $tt.flaky++ } 'partial' { $tt.partial++ } 'fail' { $tt.fail++ } 'na' { $tt.na++ } }
+        $csvRow["$t"] = $st.Label
+        $tip = [System.Web.HttpUtility]::HtmlEncode($st.Tooltip)
+        $cells += "<td class='$($st.Class)' title='$tip'>$($st.Label)</td>"
+        if ($combos) {
+            foreach ($k in ($combos.Keys | Sort-Object)) {
+                if ($combos[$k] -eq 'Failed') { [void]$failuresList.Add([pscustomobject]@{ Sample = $sample; Version = $t; Combo = $k }) }
+            }
+        }
+    }
+    $csvRows += [pscustomobject]$csvRow
+    $enc = [System.Web.HttpUtility]::HtmlEncode($sample)
+    [void]$bodyRows.Append("<tr><td class='sample'>$enc</td>$cells</tr>`n")
+}
+
+Add-Type -AssemblyName System.Web -ErrorAction SilentlyContinue
+
+# --- CSV ----------------------------------------------------------------------
+$csvRows | Export-Csv -Path (Join-Path $logsPath "$reportFileName.csv") -NoTypeInformation
+
+# --- HTML (colour-coded sample x version matrix) ------------------------------
+$generated = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$sumHead = "<tr><th>_NT_TARGET_VERSION</th><th>Release</th><th>Pass</th><th>Flaky</th><th>Partial</th><th>Fail</th><th>n/a</th><th>Combos OK</th><th>Sporadic</th><th>Failed</th><th>Excluded</th><th>Pass rate</th></tr>"
+$sumRows = ''
+foreach ($t in $tags) {
+    $x = $totals[$t]; $tot = $x.pass + $x.flaky + $x.partial + $x.fail + $x.na; $elig = $tot - $x.na
+    $rate = if ($elig -gt 0) { '{0:N0}%' -f (100.0 * ($x.pass + $x.flaky) / $elig) } else { 'n/a' }
+    $rel = $ntLabel[$t]; if (-not $rel) { $rel = '' }
+    $sumRows += "<tr><td class='sample'>$t</td><td>$rel</td><td class='pass'>$($x.pass)</td><td class='flaky'>$($x.flaky)</td><td class='partial'>$($x.partial)</td><td class='fail'>$($x.fail)</td><td class='na'>$($x.na)</td><td>$($x.S)</td><td>$($x.O)</td><td>$($x.F)</td><td>$($x.E)</td><td><b>$rate</b></td></tr>`n"
+}
+$matHead = "<tr><th class='sample'>Sample</th>"
+foreach ($t in $tags) { $rel = $ntLabel[$t]; if (-not $rel) { $rel = '' }; $matHead += "<th>$t<br><span class='sub'>$rel</span></th>" }
+$matHead += "</tr>"
+
+$html = @"
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/>
+<title>WDK Driver Samples - Build Overview</title>
+<style>
+ body{font-family:'Segoe UI',Arial,sans-serif;margin:24px;color:#1b1b1b}
+ h1{font-size:22px;margin-bottom:4px}h2{font-size:17px;margin-top:28px}
+ .meta{color:#555;font-size:13px;margin-bottom:8px}
+ table{border-collapse:collapse;margin-top:8px;font-size:13px}
+ th,td{border:1px solid #cfcfcf;padding:5px 9px;text-align:center}
+ th{background:#f0f3f7;position:sticky;top:0}
+ td.sample,th.sample{text-align:left;font-family:Consolas,monospace;white-space:nowrap}
+ .sub{font-weight:normal;color:#666;font-size:11px}
+ .pass{background:#c8e6c9}.flaky{background:#fff59d}.partial{background:#ffcc80}.fail{background:#ef9a9a}.na{background:#eee;color:#888}
+ .legend span{display:inline-block;padding:3px 9px;margin-right:6px;border:1px solid #cfcfcf;border-radius:3px;font-size:12px}
+</style></head><body>
+<h1>WDK Driver Samples &mdash; Build Overview</h1>
+<div class="meta">Generated: $generated &nbsp;|&nbsp; columns are <b>_NT_TARGET_VERSION</b> (library link version); hover a cell for the per-combination breakdown.</div>
+<div class="legend"><span class="pass">PASS</span><span class="flaky">PASS* (retry)</span><span class="partial">PARTIAL</span><span class="fail">FAIL</span><span class="na">-- n/a</span></div>
+<h2>Summary by _NT_TARGET_VERSION</h2>
+<table>$sumHead
+$sumRows</table>
+<h2>Sample &times; _NT_TARGET_VERSION</h2>
+<table>$matHead
+$($bodyRows.ToString())</table>
+</body></html>
+"@
+$html | Out-File -FilePath (Join-Path $logsPath "$reportFileName.htm") -Encoding UTF8
+
+# --- GitHub Actions run summary (Markdown) ------------------------------------
+if ($env:GITHUB_STEP_SUMMARY) {
+    $totalFailed = ($totals.Values | Measure-Object -Property fail -Sum).Sum + ($totals.Values | Measure-Object -Property partial -Sum).Sum
+    $icon = if ($failuresList.Count -gt 0) { ':x:' } else { ':white_check_mark:' }
+
+    $md = [System.Text.StringBuilder]::new()
+    [void]$md.AppendLine("# $icon WDK Driver Samples &mdash; Build Overview")
+    [void]$md.AppendLine()
+    [void]$md.AppendLine("Columns are **_NT_TARGET_VERSION** (the WDK library version drivers link against). Each version was built for Debug/Release x x64/arm64.")
+    [void]$md.AppendLine()
+    [void]$md.AppendLine("## Summary by _NT_TARGET_VERSION")
+    [void]$md.AppendLine("| _NT_TARGET_VERSION | Release | :white_check_mark: Pass | :warning: Flaky | :large_orange_diamond: Partial | :x: Fail | :heavy_minus_sign: n/a | Pass rate |")
+    [void]$md.AppendLine("|---|---|---:|---:|---:|---:|---:|---:|")
+    foreach ($t in $tags) {
+        $x = $totals[$t]; $tot = $x.pass + $x.flaky + $x.partial + $x.fail + $x.na; $elig = $tot - $x.na
+        $rate = if ($elig -gt 0) { '{0:N0}%' -f (100.0 * ($x.pass + $x.flaky) / $elig) } else { 'n/a' }
+        $rel = $ntLabel[$t]; if (-not $rel) { $rel = '' }
+        [void]$md.AppendLine("| ``$t`` | $rel | $($x.pass) | $($x.flaky) | $($x.partial) | $($x.fail) | $($x.na) | **$rate** |")
+    }
+    [void]$md.AppendLine()
+
+    if ($failuresList.Count -gt 0) {
+        [void]$md.AppendLine("## :x: Failures ($($failuresList.Count))")
+        [void]$md.AppendLine("| Sample | _NT_TARGET_VERSION | Config/Platform |")
+        [void]$md.AppendLine("|---|---|---|")
+        foreach ($f in ($failuresList | Sort-Object Sample, Version, Combo)) {
+            [void]$md.AppendLine("| ``$($f.Sample)`` | $($f.Version) | $($f.Combo.Replace('|','/')) |")
+        }
+        [void]$md.AppendLine()
+        [void]$md.AppendLine("> Open the matching **build** job's summary (or the ``logs-*`` artifact) for the exact compiler error.")
+    }
+    else {
+        [void]$md.AppendLine(":tada: **All combinations built successfully.**")
+    }
+
+    $md.ToString() | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}

--- a/.github/scripts/Join-CsvReports.ps1
+++ b/.github/scripts/Join-CsvReports.ps1
@@ -26,12 +26,6 @@ if (-not (Test-Path $logsPath)) {
     return
 }
 
-# --- Friendly labels for the known _NT_TARGET_VERSION build tags --------------
-$ntLabel = @{
-    '28000' = 'latest'; '26100' = '24H2'; '22621' = '22H2'; '22000' = '21H2'
-    '20348' = 'Server 2022'; '19041' = '2004'; '18362' = '1903'; '17763' = '1809'
-}
-
 # --- Load every per-job CSV ---------------------------------------------------
 # data[sample][tag][combo] = status
 $data       = @{}
@@ -130,16 +124,15 @@ $csvRows | Export-Csv -Path (Join-Path $logsPath "$reportFileName.csv") -NoTypeI
 
 # --- HTML (colour-coded sample x version matrix) ------------------------------
 $generated = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-$sumHead = "<tr><th>_NT_TARGET_VERSION</th><th>Release</th><th>Pass</th><th>Flaky</th><th>Partial</th><th>Fail</th><th>n/a</th><th>Combos OK</th><th>Sporadic</th><th>Failed</th><th>Excluded</th><th>Pass rate</th></tr>"
+$sumHead = "<tr><th>_NT_TARGET_VERSION</th><th>Pass</th><th>Flaky</th><th>Partial</th><th>Fail</th><th>n/a</th><th>Combos OK</th><th>Sporadic</th><th>Failed</th><th>Excluded</th><th>Pass rate</th></tr>"
 $sumRows = ''
 foreach ($t in $tags) {
     $x = $totals[$t]; $tot = $x.pass + $x.flaky + $x.partial + $x.fail + $x.na; $elig = $tot - $x.na
     $rate = if ($elig -gt 0) { '{0:N0}%' -f (100.0 * ($x.pass + $x.flaky) / $elig) } else { 'n/a' }
-    $rel = $ntLabel[$t]; if (-not $rel) { $rel = '' }
-    $sumRows += "<tr><td class='sample'>$t</td><td>$rel</td><td class='pass'>$($x.pass)</td><td class='flaky'>$($x.flaky)</td><td class='partial'>$($x.partial)</td><td class='fail'>$($x.fail)</td><td class='na'>$($x.na)</td><td>$($x.S)</td><td>$($x.O)</td><td>$($x.F)</td><td>$($x.E)</td><td><b>$rate</b></td></tr>`n"
+    $sumRows += "<tr><td class='sample'>$t</td><td class='pass'>$($x.pass)</td><td class='flaky'>$($x.flaky)</td><td class='partial'>$($x.partial)</td><td class='fail'>$($x.fail)</td><td class='na'>$($x.na)</td><td>$($x.S)</td><td>$($x.O)</td><td>$($x.F)</td><td>$($x.E)</td><td><b>$rate</b></td></tr>`n"
 }
 $matHead = "<tr><th class='sample'>Sample</th>"
-foreach ($t in $tags) { $rel = $ntLabel[$t]; if (-not $rel) { $rel = '' }; $matHead += "<th>$t<br><span class='sub'>$rel</span></th>" }
+foreach ($t in $tags) { $matHead += "<th>$t</th>" }
 $matHead += "</tr>"
 
 $html = @"
@@ -181,13 +174,12 @@ if ($env:GITHUB_STEP_SUMMARY) {
     [void]$md.AppendLine("Columns are **_NT_TARGET_VERSION** (the WDK library version drivers link against). Each version was built for Debug/Release x x64/arm64.")
     [void]$md.AppendLine()
     [void]$md.AppendLine("## Summary by _NT_TARGET_VERSION")
-    [void]$md.AppendLine("| _NT_TARGET_VERSION | Release | :white_check_mark: Pass | :warning: Flaky | :large_orange_diamond: Partial | :x: Fail | :heavy_minus_sign: n/a | Pass rate |")
-    [void]$md.AppendLine("|---|---|---:|---:|---:|---:|---:|---:|")
+    [void]$md.AppendLine("| _NT_TARGET_VERSION | :white_check_mark: Pass | :warning: Flaky | :large_orange_diamond: Partial | :x: Fail | :heavy_minus_sign: n/a | Pass rate |")
+    [void]$md.AppendLine("|---|---:|---:|---:|---:|---:|---:|")
     foreach ($t in $tags) {
         $x = $totals[$t]; $tot = $x.pass + $x.flaky + $x.partial + $x.fail + $x.na; $elig = $tot - $x.na
         $rate = if ($elig -gt 0) { '{0:N0}%' -f (100.0 * ($x.pass + $x.flaky) / $elig) } else { 'n/a' }
-        $rel = $ntLabel[$t]; if (-not $rel) { $rel = '' }
-        [void]$md.AppendLine("| ``$t`` | $rel | $($x.pass) | $($x.flaky) | $($x.partial) | $($x.fail) | $($x.na) | **$rate** |")
+        [void]$md.AppendLine("| ``$t`` | $($x.pass) | $($x.flaky) | $($x.partial) | $($x.fail) | $($x.na) | **$rate** |")
     }
     [void]$md.AppendLine()
 

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -1,5 +1,7 @@
 # This workflow runs the latest CodeQL CLI and checks against CodeQL's Cpp library.
 # This is the source for the GitHub Security Code Scanning job.
+# Samples are split across 4 parallel shards to reduce total wall-clock time while
+# keeping ThrottleLimit 1 per shard (required for accurate CodeQL tracing).
 
 name: "CodeQL Analysis"
 
@@ -25,7 +27,7 @@ on:
 
 jobs:
   analyze:
-    name: Analysis
+    name: Analysis (shard ${{ matrix.shard }})
     runs-on: windows-latest
     permissions:
       actions: read
@@ -35,43 +37,58 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - language: c-cpp
-          build-mode: manual
+        language: [c-cpp]
+        shard: [0, 1, 2, 3]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+
       - name: Install Nuget Packages
         run: nuget restore .\packages.config -PackagesDirectory .\packages\
+
       - name: Get changed files
         id: get-changed-files
         uses: tj-actions/changed-files@v41
         with:
           separator: ","
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          build-mode: manual
           config-file: microsoft/Windows-Driver-Developer-Supplemental-Tools/config/codeql-config.yml@development
+
       - if: github.event_name == 'pull_request'
+        name: Build changed samples (PR)
         run: |
           $changedFiles = "${{ steps.get-changed-files.outputs.all_changed_files }}".Split(',')
           .\.github\scripts\Build-ChangedSamples.ps1 -ChangedFiles $changedFiles -Verbose
-        env: 
-          WDS_Configuration: Debug
-          WDS_Platform: x64
-          WDS_WipeOutputs: ${{ true }}
-      - if: github.event_name == 'push'
-        run: .\Build-Samples.ps1 -Verbose -ThrottleLimit 1
         env:
           WDS_Configuration: Debug
           WDS_Platform: x64
           WDS_WipeOutputs: ${{ true }}
+
+      - if: github.event_name != 'pull_request'
+        name: Build sample shard ${{ matrix.shard }} of 4
+        run: |
+          $totalShards = 4
+          $shardIndex  = ${{ matrix.shard }}
+          $allSamples  = .\ListAllSamples.ps1
+          $shardSize   = [Math]::Ceiling($allSamples.Count / $totalShards)
+          $start       = $shardIndex * $shardSize
+          $mySamples   = $allSamples | Select-Object -Skip $start -First $shardSize
+          Write-Output "Shard $shardIndex/$totalShards — building $($mySamples.Count) of $($allSamples.Count) samples (indices $start..$($start + $mySamples.Count - 1))"
+          .\Build-Samples.ps1 -Samples $mySamples -Verbose -ThrottleLimit 1
+        env:
+          WDS_Configuration: Debug
+          WDS_Platform: x64
+          WDS_WipeOutputs: ${{ true }}
+
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:${{ matrix.language }}/shard-${{ matrix.shard }}"

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -1,7 +1,8 @@
 # This workflow runs the latest CodeQL CLI and checks against CodeQL's Cpp library.
 # This is the source for the GitHub Security Code Scanning job.
-# Samples are split across 4 parallel shards to reduce total wall-clock time while
-# keeping ThrottleLimit 1 per shard (required for accurate CodeQL tracing).
+# On push/schedule: samples are split across 4 parallel shards to reduce wall-clock
+# time while keeping ThrottleLimit 1 per shard (required for accurate CodeQL tracing).
+# On pull_request: only changed samples are built in a single job (no sharding needed).
 
 name: "CodeQL Analysis"
 
@@ -26,8 +27,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  analyze:
-    name: Analysis (shard ${{ matrix.shard }} of 4)
+  # -----------------------------------------------------------------------
+  # PR job: single runner, builds only changed samples
+  # -----------------------------------------------------------------------
+  analyze-pr:
+    name: Analysis (PR)
+    if: github.event_name == 'pull_request'
     runs-on: windows-latest
     permissions:
       actions: read
@@ -39,7 +44,6 @@ jobs:
       matrix:
         language: [c-cpp]
         build-mode: [manual]
-        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout repository
@@ -63,8 +67,7 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           config-file: microsoft/Windows-Driver-Developer-Supplemental-Tools/config/codeql-config.yml@development
 
-      - if: github.event_name == 'pull_request'
-        name: Build changed samples (PR)
+      - name: Build changed samples (PR)
         run: |
           $changedFiles = "${{ steps.get-changed-files.outputs.all_changed_files }}".Split(',')
           .\.github\scripts\Build-ChangedSamples.ps1 -ChangedFiles $changedFiles -Verbose
@@ -73,8 +76,47 @@ jobs:
           WDS_Platform: x64
           WDS_WipeOutputs: ${{ true }}
 
-      - if: github.event_name != 'pull_request'
-        name: Build sample shard ${{ matrix.shard }} of 4
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # -----------------------------------------------------------------------
+  # Push/schedule job: 4 parallel shards, each builds a slice of all samples
+  # -----------------------------------------------------------------------
+  analyze:
+    name: Analysis (shard ${{ matrix.shard }} of 4)
+    if: github.event_name != 'pull_request'
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [c-cpp]
+        build-mode: [manual]
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install Nuget Packages
+        run: nuget restore .\packages.config -PackagesDirectory .\packages\
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: microsoft/Windows-Driver-Developer-Supplemental-Tools/config/codeql-config.yml@development
+
+      - name: Build sample shard ${{ matrix.shard }} of 4
         run: |
           $totalShards = 4
           $shardIndex  = ${{ matrix.shard }} - 1

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   analyze:
-    name: Analysis (shard ${{ matrix.shard }})
+    name: Analysis (shard ${{ matrix.shard + 1 }} of 4)
     runs-on: windows-latest
     permissions:
       actions: read
@@ -38,6 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [c-cpp]
+        build-mode: [manual]
         shard: [0, 1, 2, 3]
 
     steps:
@@ -59,7 +60,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          build-mode: manual
+          build-mode: ${{ matrix.build-mode }}
           config-file: microsoft/Windows-Driver-Developer-Supplemental-Tools/config/codeql-config.yml@development
 
       - if: github.event_name == 'pull_request'
@@ -73,7 +74,7 @@ jobs:
           WDS_WipeOutputs: ${{ true }}
 
       - if: github.event_name != 'pull_request'
-        name: Build sample shard ${{ matrix.shard }} of 4
+        name: Build sample shard ${{ matrix.shard + 1 }} of 4
         run: |
           $totalShards = 4
           $shardIndex  = ${{ matrix.shard }}
@@ -81,7 +82,7 @@ jobs:
           $shardSize   = [Math]::Ceiling($allSamples.Count / $totalShards)
           $start       = $shardIndex * $shardSize
           $mySamples   = $allSamples | Select-Object -Skip $start -First $shardSize
-          Write-Output "Shard $shardIndex/$totalShards — building $($mySamples.Count) of $($allSamples.Count) samples (indices $start..$($start + $mySamples.Count - 1))"
+          Write-Output "Shard $($shardIndex + 1)/$totalShards — building $($mySamples.Count) of $($allSamples.Count) samples (indices $start..$($start + $mySamples.Count - 1))"
           .\Build-Samples.ps1 -Samples $mySamples -Verbose -ThrottleLimit 1
         env:
           WDS_Configuration: Debug

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -56,7 +56,7 @@ jobs:
           separator: ","
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: manual
@@ -89,6 +89,6 @@ jobs:
           WDS_WipeOutputs: ${{ true }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}/shard-${{ matrix.shard }}"

--- a/.github/workflows/Code-Scanning.yml
+++ b/.github/workflows/Code-Scanning.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   analyze:
-    name: Analysis (shard ${{ matrix.shard + 1 }} of 4)
+    name: Analysis (shard ${{ matrix.shard }} of 4)
     runs-on: windows-latest
     permissions:
       actions: read
@@ -39,7 +39,7 @@ jobs:
       matrix:
         language: [c-cpp]
         build-mode: [manual]
-        shard: [0, 1, 2, 3]
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: Checkout repository
@@ -74,15 +74,15 @@ jobs:
           WDS_WipeOutputs: ${{ true }}
 
       - if: github.event_name != 'pull_request'
-        name: Build sample shard ${{ matrix.shard + 1 }} of 4
+        name: Build sample shard ${{ matrix.shard }} of 4
         run: |
           $totalShards = 4
-          $shardIndex  = ${{ matrix.shard }}
+          $shardIndex  = ${{ matrix.shard }} - 1
           $allSamples  = .\ListAllSamples.ps1
           $shardSize   = [Math]::Ceiling($allSamples.Count / $totalShards)
           $start       = $shardIndex * $shardSize
           $mySamples   = $allSamples | Select-Object -Skip $start -First $shardSize
-          Write-Output "Shard $($shardIndex + 1)/$totalShards — building $($mySamples.Count) of $($allSamples.Count) samples (indices $start..$($start + $mySamples.Count - 1))"
+          Write-Output "Shard ${{ matrix.shard }}/$totalShards — building $($mySamples.Count) of $($allSamples.Count) samples (indices $start..$($start + $mySamples.Count - 1))"
           .\Build-Samples.ps1 -Samples $mySamples -Verbose -ThrottleLimit 1
         env:
           WDS_Configuration: Debug

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,20 +8,39 @@ on:
       - '**.md'
       - 'LICENSE'
 jobs:
+  # Auto-discover the available _NT_TARGET_VERSION values from the active WDK so the build
+  # matrix never needs a hand-maintained version list. Change -Newest to build more/fewer.
+  discover:
+    name: discover _NT_TARGET_VERSIONs
+    runs-on: windows-2025-vs2026
+    outputs:
+      versions: ${{ steps.nt.outputs.versions }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install Nuget Packages
+        run: nuget restore .\packages.config -PackagesDirectory .\packages\
+
+      - name: Discover the newest _NT_TARGET_VERSION values
+        id: nt
+        shell: pwsh
+        run: |
+          $json = .\Get-NtTargetVersions.ps1 -Newest 4 -AsMatrixJson
+          "versions=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Discovered _NT_TARGET_VERSION matrix: $json"
+
   build:
     name: build ${{ matrix.nt.tag }} ${{ matrix.configuration }} ${{ matrix.platform }}
+    needs: discover
     strategy:
       fail-fast: false
       matrix:
         configuration: [Debug, Release]
         platform: [x64, arm64]
-        # _NT_TARGET_VERSION = the WDK library version drivers link against (newest first).
-        # Each { version, tag } runs as its own parallel job; trim this list to reduce CI load.
-        nt:
-          - { version: '10.0.28000', tag: '28000' }
-          - { version: '10.0.26100', tag: '26100' }
-          - { version: '10.0.22621', tag: '22621' }
-          - { version: '10.0.22000', tag: '22000' }
+        # _NT_TARGET_VERSION values are auto-discovered by the 'discover' job from the active
+        # WDK, so there is no version list to maintain here.
+        nt: ${{ fromJSON(needs.discover.outputs.versions) }}
     runs-on: windows-2025-vs2026
     steps:
       - name: Check out repository code

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,12 +9,19 @@ on:
       - 'LICENSE'
 jobs:
   build:
-    name: Build driver samples
+    name: build ${{ matrix.nt.tag }} ${{ matrix.configuration }} ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
         configuration: [Debug, Release]
         platform: [x64, arm64]
+        # _NT_TARGET_VERSION = the WDK library version drivers link against (newest first).
+        # Each { version, tag } runs as its own parallel job; trim this list to reduce CI load.
+        nt:
+          - { version: '10.0.28000', tag: '28000' }
+          - { version: '10.0.26100', tag: '26100' }
+          - { version: '10.0.22621', tag: '22621' }
+          - { version: '10.0.22000', tag: '22000' }
     runs-on: windows-2025-vs2026
     steps:
       - name: Check out repository code
@@ -38,13 +45,14 @@ jobs:
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
-          WDS_ReportFileName: _overview.${{ matrix.configuration }}.${{ matrix.platform }}
+          WDS_NtTargetVersion: ${{ matrix.nt.version }}
+          WDS_ReportFileName: _overview.${{ matrix.nt.tag }}.${{ matrix.configuration }}.${{ matrix.platform }}
 
       - name: Archive build logs and overview build reports
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs-${{ matrix.configuration }}-${{ matrix.platform }}
+          name: logs-${{ matrix.nt.tag }}-${{ matrix.configuration }}-${{ matrix.platform }}
           path: _logs
   
   report:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,19 @@ on:
     - cron: '0 8 * * 6'
 jobs:
   build:
-    name: Build driver samples
+    name: build ${{ matrix.nt.tag }} ${{ matrix.configuration }} ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
         configuration: [Debug, Release]
         platform: [x64, arm64]
+        # _NT_TARGET_VERSION = the WDK library version drivers link against (newest first).
+        # Each { version, tag } runs as its own parallel job; trim this list to reduce CI load.
+        nt:
+          - { version: '10.0.28000', tag: '28000' }
+          - { version: '10.0.26100', tag: '26100' }
+          - { version: '10.0.22621', tag: '22621' }
+          - { version: '10.0.22000', tag: '22000' }
     runs-on: windows-2025-vs2026
     steps:
       - name: Check out repository code
@@ -33,13 +40,14 @@ jobs:
         env:
           WDS_Configuration: ${{ matrix.configuration }}
           WDS_Platform: ${{ matrix.platform }}
-          WDS_ReportFileName: _overview.${{ matrix.configuration }}.${{ matrix.platform }}
+          WDS_NtTargetVersion: ${{ matrix.nt.version }}
+          WDS_ReportFileName: _overview.${{ matrix.nt.tag }}.${{ matrix.configuration }}.${{ matrix.platform }}
 
       - name: Archive build logs and overview build reports
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logs-${{ matrix.configuration }}-${{ matrix.platform }}
+          name: logs-${{ matrix.nt.tag }}-${{ matrix.configuration }}-${{ matrix.platform }}
           path: _logs
 
   report:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,39 @@ on:
     # Runs every Saturday at 00:00 PST (08:00 UTC)
     - cron: '0 8 * * 6'
 jobs:
+  # Auto-discover the available _NT_TARGET_VERSION values from the active WDK so the build
+  # matrix never needs a hand-maintained version list. Change -Newest to build more/fewer.
+  discover:
+    name: discover _NT_TARGET_VERSIONs
+    runs-on: windows-2025-vs2026
+    outputs:
+      versions: ${{ steps.nt.outputs.versions }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install Nuget Packages
+        run: nuget restore .\packages.config -PackagesDirectory .\packages\
+
+      - name: Discover the newest _NT_TARGET_VERSION values
+        id: nt
+        shell: pwsh
+        run: |
+          $json = .\Get-NtTargetVersions.ps1 -Newest 4 -AsMatrixJson
+          "versions=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Discovered _NT_TARGET_VERSION matrix: $json"
+
   build:
     name: build ${{ matrix.nt.tag }} ${{ matrix.configuration }} ${{ matrix.platform }}
+    needs: discover
     strategy:
       fail-fast: false
       matrix:
         configuration: [Debug, Release]
         platform: [x64, arm64]
-        # _NT_TARGET_VERSION = the WDK library version drivers link against (newest first).
-        # Each { version, tag } runs as its own parallel job; trim this list to reduce CI load.
-        nt:
-          - { version: '10.0.28000', tag: '28000' }
-          - { version: '10.0.26100', tag: '26100' }
-          - { version: '10.0.22621', tag: '22621' }
-          - { version: '10.0.22000', tag: '22000' }
+        # _NT_TARGET_VERSION values are auto-discovered by the 'discover' job from the active
+        # WDK, so there is no version list to maintain here.
+        nt: ${{ fromJSON(needs.discover.outputs.versions) }}
     runs-on: windows-2025-vs2026
     steps:
       - name: Check out repository code

--- a/Build-Samples.ps1
+++ b/Build-Samples.ps1
@@ -119,15 +119,21 @@ function Import-SampleExclusions {
           - Configurations: semicolon-separated config|platform patterns (or '*' for all)
           - Reason:         human-readable explanation
 
-        Only exclusions whose [MinBuild, MaxBuild] range includes the given build number
-        are returned. Exclusions outside the range are silently skipped.
+        A row is only returned when BOTH of the following match the current build:
+          - its [MinBuild, MaxBuild] range includes the given build number, and
+          - its TargetVersions list matches the given TargetVersion. TargetVersions is
+            blank/'*' for all versions, or a ';'-separated list of -like patterns
+            (e.g. 'Windows8', 'Windows7;Windows8', 'Windows*').
+        Rows outside the build range, or whose TargetVersions does not match, are skipped.
     .NOTES
-        CSV format:  Path,Configurations,MinBuild,MaxBuild,Reason
-        Example row: network\wlan\wdi,*,,27100,"failure introduced in VS17.14"
+        CSV format:  Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
+        Example row: network\wlan\wdi,*,,,27100,"failure introduced in VS17.14"
+        Target-specific: somepath,*|ARM64,Windows8,,,"ARM not supported when targeting Windows 8"
     #>
     param(
         [string]$CsvPath,
-        [int]$BuildNumber
+        [int]$BuildNumber,
+        [string]$TargetVersion = 'Windows10'
     )
 
     if (-not (Test-Path $CsvPath)) {
@@ -139,16 +145,24 @@ function Import-SampleExclusions {
     Import-Csv $CsvPath | ForEach-Object {
         $pattern  = $_.Path.Trim('\').Replace('\', '.').ToLower()
         $configs  = if ([string]::IsNullOrWhiteSpace($_.Configurations)) { '*' } else { $_.Configurations }
+        # TargetVersions column is optional; blank or missing means "all target versions".
+        $targets  = if ([string]::IsNullOrWhiteSpace($_.TargetVersions)) { '*' } else { $_.TargetVersions }
         $minBuild = if ([string]::IsNullOrWhiteSpace($_.MinBuild)) { 0 }     else { [int]$_.MinBuild }
         $maxBuild = if ([string]::IsNullOrWhiteSpace($_.MaxBuild)) { 99999 } else { [int]$_.MaxBuild }
 
-        if ($minBuild -le $BuildNumber -and $BuildNumber -le $maxBuild) {
+        # TargetVersion is constant for the whole run, so (like the build number) filter here.
+        $targetMatches = $targets.Split(';') | Where-Object { $TargetVersion -like $_.Trim() }
+
+        if (-not $targetMatches) {
+            Write-Verbose "Exclusion skipped: '$pattern' - target '$TargetVersion' not in '$targets'"
+        }
+        elseif ($minBuild -le $BuildNumber -and $BuildNumber -le $maxBuild) {
             [void]$exclusions.Add([PSCustomObject]@{
                 Pattern        = $pattern
                 Configurations = $configs
                 Reason         = $_.Reason
             })
-            Write-Verbose "Exclusion applied: '$pattern' configs='$configs' reason='$($_.Reason)'"
+            Write-Verbose "Exclusion applied: '$pattern' configs='$configs' targets='$targets' reason='$($_.Reason)'"
         }
         else {
             Write-Verbose "Exclusion skipped: '$pattern' - build $BuildNumber outside [$minBuild, $maxBuild]"
@@ -414,7 +428,7 @@ else {
 #  Step 6 - Load Exclusions
 # =============================================================================
 
-$exclusions = Import-SampleExclusions -CsvPath (Join-Path $root 'exclusions.csv') -BuildNumber $buildNumber
+$exclusions = Import-SampleExclusions -CsvPath (Join-Path $root 'exclusions.csv') -BuildNumber $buildNumber -TargetVersion $TargetVersion
 
 # =============================================================================
 #  Step 7 - Print Build Plan

--- a/Build-Samples.ps1
+++ b/Build-Samples.ps1
@@ -131,7 +131,7 @@ function Import-SampleExclusions {
     param(
         [string]$CsvPath,
         [int]$BuildNumber,
-        [string]$NtTargetVersion = '10.0.28000'
+        [string]$NtTargetVersion
     )
 
     if (-not (Test-Path $CsvPath)) {
@@ -140,8 +140,14 @@ function Import-SampleExclusions {
     }
 
     # The _NT_TARGET_VERSION param is the friendly build-number form (e.g. '10.0.22000');
-    # take its last dotted component for numeric range comparisons.
-    $ntBuild = [int]($NtTargetVersion -replace '.*\.', '')
+    # take its last dotted component for numeric range comparisons. An empty value (or
+    # 'latest') means the newest libraries, so no NT-version-scoped row applies.
+    $ntBuild = if ([string]::IsNullOrWhiteSpace($NtTargetVersion) -or $NtTargetVersion -eq 'latest') {
+        [int]::MaxValue
+    }
+    else {
+        [int]($NtTargetVersion -replace '.*\.', '')
+    }
 
     $exclusions = [System.Collections.ArrayList]::new()
     Import-Csv $CsvPath | ForEach-Object {
@@ -151,7 +157,7 @@ function Import-SampleExclusions {
         $maxBuild = if ([string]::IsNullOrWhiteSpace($_.MaxBuild)) { 99999 } else { [int]$_.MaxBuild }
         # Min/MaxNtTargetVersion columns are optional; blank or missing means "all NT versions".
         $minNt    = if ([string]::IsNullOrWhiteSpace($_.MinNtTargetVersion)) { 0 }       else { [int]$_.MinNtTargetVersion }
-        $maxNt    = if ([string]::IsNullOrWhiteSpace($_.MaxNtTargetVersion)) { 9999999 } else { [int]$_.MaxNtTargetVersion }
+        $maxNt    = if ([string]::IsNullOrWhiteSpace($_.MaxNtTargetVersion)) { [int]::MaxValue } else { [int]$_.MaxNtTargetVersion }
 
         # _NT_TARGET_VERSION is constant for the whole run, so (like the build number) filter
         # these rows out here at load time.
@@ -205,7 +211,7 @@ function Build-SingleSample {
         [string]$SampleName,
         [string]$Configuration = 'Debug',
         [string]$Platform = 'x64',
-        [string]$NtTargetVersionCode = '0xA000012',
+        [string]$NtTargetVersionCode,
         [string]$InfVerif_AdditionalOptions = '/samples',
         [string]$LogFilesDirectory = (Get-Location),
         [bool]$Verbose = $false

--- a/Build-Samples.ps1
+++ b/Build-Samples.ps1
@@ -130,27 +130,36 @@ function Import-SampleExclusions {
           - Configurations: semicolon-separated config|platform patterns (or '*' for all)
           - Reason:         human-readable explanation
 
-        A row is only returned when BOTH of the following match the current build:
-          - its [MinBuild, MaxBuild] range includes the given build number, and
+        A row is only returned when ALL of the following match the current build:
+          - its [MinBuild, MaxBuild] range includes the given build number,
+          - its [MinNtTargetVersion, MaxNtTargetVersion] range includes the current
+            _NT_TARGET_VERSION build number (e.g. 22000 parsed from '10.0.22000'), and
           - its TargetVersions list matches the given TargetVersion. TargetVersions is
             blank/'*' for all versions, or a ';'-separated list of -like patterns
             (e.g. 'Windows8', 'Windows7;Windows8', 'Windows*').
-        Rows outside the build range, or whose TargetVersions does not match, are skipped.
+        Rows outside any range, or whose TargetVersions does not match, are skipped.
+        MinBuild/MaxBuild and MinNtTargetVersion/MaxNtTargetVersion are blank = unbounded.
     .NOTES
-        CSV format:  Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
-        Example row: network\wlan\wdi,*,,,27100,"failure introduced in VS17.14"
-        Target-specific: somepath,*|ARM64,Windows8,,,"ARM not supported when targeting Windows 8"
+        CSV format:  Path,Configurations,TargetVersions,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
+        Example row:         network\wlan\wdi,*,,,27100,,,"failure introduced in VS17.14"
+        Target-specific:     somepath,*|ARM64,Windows8,,,,,"ARM not supported when targeting Windows 8"
+        NT-version-specific: somepath,*,,,,,22621,"needs an API newer than the 10.0.22621 library"
     #>
     param(
         [string]$CsvPath,
         [int]$BuildNumber,
-        [string]$TargetVersion = 'Windows10'
+        [string]$TargetVersion = 'Windows10',
+        [string]$NtTargetVersion = '10.0.28000'
     )
 
     if (-not (Test-Path $CsvPath)) {
         Write-Warning "Exclusions file not found: $CsvPath. No exclusions will be applied."
         return @()
     }
+
+    # The _NT_TARGET_VERSION param is the friendly build-number form (e.g. '10.0.22000');
+    # take its last dotted component for numeric range comparisons.
+    $ntBuild = [int]($NtTargetVersion -replace '.*\.', '')
 
     $exclusions = [System.Collections.ArrayList]::new()
     Import-Csv $CsvPath | ForEach-Object {
@@ -160,12 +169,19 @@ function Import-SampleExclusions {
         $targets  = if ([string]::IsNullOrWhiteSpace($_.TargetVersions)) { '*' } else { $_.TargetVersions }
         $minBuild = if ([string]::IsNullOrWhiteSpace($_.MinBuild)) { 0 }     else { [int]$_.MinBuild }
         $maxBuild = if ([string]::IsNullOrWhiteSpace($_.MaxBuild)) { 99999 } else { [int]$_.MaxBuild }
+        # Min/MaxNtTargetVersion columns are optional; blank or missing means "all NT versions".
+        $minNt    = if ([string]::IsNullOrWhiteSpace($_.MinNtTargetVersion)) { 0 }       else { [int]$_.MinNtTargetVersion }
+        $maxNt    = if ([string]::IsNullOrWhiteSpace($_.MaxNtTargetVersion)) { 9999999 } else { [int]$_.MaxNtTargetVersion }
 
-        # TargetVersion is constant for the whole run, so (like the build number) filter here.
+        # TargetVersion and _NT_TARGET_VERSION are constant for the whole run, so (like the
+        # build number) filter these rows out here at load time.
         $targetMatches = $targets.Split(';') | Where-Object { $TargetVersion -like $_.Trim() }
 
         if (-not $targetMatches) {
             Write-Verbose "Exclusion skipped: '$pattern' - target '$TargetVersion' not in '$targets'"
+        }
+        elseif ($ntBuild -lt $minNt -or $ntBuild -gt $maxNt) {
+            Write-Verbose "Exclusion skipped: '$pattern' - _NT_TARGET_VERSION $ntBuild outside [$minNt, $maxNt]"
         }
         elseif ($minBuild -le $BuildNumber -and $BuildNumber -le $maxBuild) {
             [void]$exclusions.Add([PSCustomObject]@{
@@ -173,7 +189,7 @@ function Import-SampleExclusions {
                 Configurations = $configs
                 Reason         = $_.Reason
             })
-            Write-Verbose "Exclusion applied: '$pattern' configs='$configs' targets='$targets' reason='$($_.Reason)'"
+            Write-Verbose "Exclusion applied: '$pattern' configs='$configs' targets='$targets' ntRange=[$minNt,$maxNt] reason='$($_.Reason)'"
         }
         else {
             Write-Verbose "Exclusion skipped: '$pattern' - build $BuildNumber outside [$minBuild, $maxBuild]"
@@ -457,7 +473,7 @@ $ntTargetVersionCode = $ntTargetVersionCodes[$NtTargetVersion]
 #  Step 6 - Load Exclusions
 # =============================================================================
 
-$exclusions = Import-SampleExclusions -CsvPath (Join-Path $root 'exclusions.csv') -BuildNumber $buildNumber -TargetVersion $TargetVersion
+$exclusions = Import-SampleExclusions -CsvPath (Join-Path $root 'exclusions.csv') -BuildNumber $buildNumber -TargetVersion $TargetVersion -NtTargetVersion $NtTargetVersion
 
 # =============================================================================
 #  Step 7 - Print Build Plan
@@ -724,4 +740,56 @@ $sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview - TargetVersio
 # Only open the HTML report interactively (not in CI/automation)
 if (-not $env:BUILD_BUILDID -and [Environment]::UserInteractive) {
     Invoke-Item $reportHtmlPath
+}
+
+# =============================================================================
+#  Step 12 - GitHub Actions job summary (CI only; no-op when run locally)
+# =============================================================================
+# When $GITHUB_STEP_SUMMARY is set, emit an easy-to-scan markdown summary for the run
+# page: a status header, a counts table, and (if any) a table of failures with the first
+# compiler/linker error so problems are obvious without opening the logs.
+if ($env:GITHUB_STEP_SUMMARY) {
+    $icon = if ($buildState.Failed -gt 0) { ':x:' } elseif ($buildState.Sporadic -gt 0) { ':warning:' } else { ':white_check_mark:' }
+    $cfgLabel = "$($Configurations -join ',')|$($Platforms -join ',')"
+
+    $md = [System.Text.StringBuilder]::new()
+    [void]$md.AppendLine("## $icon ``$cfgLabel`` &nbsp;&middot;&nbsp; _NT_TARGET_VERSION ``$NtTargetVersion``")
+    [void]$md.AppendLine()
+    [void]$md.AppendLine("Environment **$($buildEnv.Name)** &middot; WDK build **$buildNumber** &middot; TargetVersion **$TargetVersion** &middot; **$($sampleSet.Count)** samples &middot; $($elapsed.Minutes)m $($elapsed.Seconds)s")
+    [void]$md.AppendLine()
+    [void]$md.AppendLine("| :white_check_mark: Succeeded | :x: Failed | :warning: Sporadic | :heavy_minus_sign: Excluded | :grey_question: Unsupported |")
+    [void]$md.AppendLine("|---:|---:|---:|---:|---:|")
+    [void]$md.AppendLine("| $($buildState.Succeeded) | $($buildState.Failed) | $($buildState.Sporadic) | $($buildState.Excluded) | $($buildState.Unsupported) |")
+    [void]$md.AppendLine()
+
+    if ($buildState.FailSet.Count -gt 0) {
+        [void]$md.AppendLine("<details open><summary><b>:x: $($buildState.FailSet.Count) failed</b></summary>")
+        [void]$md.AppendLine()
+        [void]$md.AppendLine("| Sample | Config/Platform | First error |")
+        [void]$md.AppendLine("|---|---|---|")
+        foreach ($entry in ($buildState.FailSet | Sort-Object)) {
+            if ($entry -match '^(?<name>.*)\s+(?<config>\w+)\|(?<platform>\w+)$') {
+                $fName = $Matches.name; $fConfig = $Matches.config; $fPlatform = $Matches.platform
+                $errLog = Join-Path $LogFilesDirectory "$fName.$fConfig.$fPlatform.0.err"
+                $msg = ''
+                if (Test-Path $errLog) {
+                    $line = Get-Content $errLog | Where-Object { $_ -match ': (error|fatal error) ' } | Select-Object -First 1
+                    if ($line -match ':\s*((?:fatal )?error\s.+?)\s*\[[^\[]*\]\s*$') { $msg = $Matches[1] } else { $msg = $line }
+                }
+                $msg = ("$msg" -replace '\|', '\|').Trim()
+                if ($msg.Length -gt 180) { $msg = $msg.Substring(0, 177) + '...' }
+                [void]$md.AppendLine("| ``$fName`` | $fConfig/$fPlatform | $msg |")
+            }
+        }
+        [void]$md.AppendLine("</details>")
+        [void]$md.AppendLine()
+    }
+
+    if ($buildState.SporadicSet.Count -gt 0) {
+        $sp = ($buildState.SporadicSet | Sort-Object | ForEach-Object { "``$_``" }) -join ', '
+        [void]$md.AppendLine(":warning: **Sporadic** (passed on retry): $sp")
+        [void]$md.AppendLine()
+    }
+
+    $md.ToString() | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 }

--- a/Build-Samples.ps1
+++ b/Build-Samples.ps1
@@ -27,21 +27,13 @@
 .PARAMETER Platforms
     Build platforms (e.g. 'x64','arm64'). Defaults to $env:WDS_Platform or ('x64','arm64').
 
-.PARAMETER TargetVersion
-    Target OS version the drivers are built for (the msbuild 'TargetVersion' property).
-    Valid values are defined by the WDK DriverGeneral.xml rule and are listed newest-first:
-      Windows10    - Windows 10 or higher (default, latest)
-      WindowsV6.3  - Windows 8.1
-      Windows8     - Windows 8
-      Windows7     - Windows 7
-    Defaults to $env:WDS_TargetVersion, or 'Windows10' (the latest) when unset.
-
 .PARAMETER NtTargetVersion
     The _NT_TARGET_VERSION value - the WDK library version the driver links against
-    ("OS version of libraries"), which is independent of the Target OS Version. Accepts the
-    Windows build-number form (e.g. '10.0.28000'); valid values come from the WDK
-    DriverGeneral.xml rule and are listed newest-first. Defaults to $env:WDS_NtTargetVersion,
-    or '10.0.28000' (the latest) when unset.
+    ("OS version of libraries"). Accepts the Windows build-number form '10.0.<build>' or the
+    short '<build>' tag (e.g. '10.0.28000' or '28000'). The valid values are auto-discovered
+    from the active WDK's DriverGeneral.xml rule (see Get-NtTargetVersions.ps1), so a new WDK
+    version is picked up with no script change. Defaults to $env:WDS_NtTargetVersion, or the
+    latest discovered version when unset.
 
 .PARAMETER LogFilesDirectory
     Directory for build log files. Defaults to _logs in the current directory.
@@ -87,9 +79,9 @@
     Forces WDK mode regardless of environment variables.
 
 .EXAMPLE
-    .\Build-Samples -TargetVersion Windows7
+    .\Build-Samples -NtTargetVersion 10.0.22000
 
-    Builds all samples targeting Windows 7 instead of the default (latest) Windows10.
+    Builds all samples linking against the 10.0.22000 library set instead of the latest.
 #>
 
 #Requires -Version 7.0
@@ -99,13 +91,9 @@ param(
     [string[]]$Samples,
     [string[]]$Configurations = @(if ([string]::IsNullOrEmpty($env:WDS_Configuration)) { ('Debug', 'Release') } else { $env:WDS_Configuration }),
     [string[]]$Platforms = @(if ([string]::IsNullOrEmpty($env:WDS_Platform)) { ('x64', 'arm64') } else { $env:WDS_Platform }),
-    # Valid TargetVersion values come from the WDK DriverGeneral.xml rule (newest first).
-    [ValidateSet('Windows10', 'WindowsV6.3', 'Windows8', 'Windows7')]
-    [string]$TargetVersion = $(if ([string]::IsNullOrEmpty($env:WDS_TargetVersion)) { 'Windows10' } else { $env:WDS_TargetVersion }),
-    # _NT_TARGET_VERSION = the WDK library version the driver links against (newest first;
-    # values come from the WDK DriverGeneral.xml rule). Default is the latest.
-    [ValidateSet('10.0.28000', '10.0.26100', '10.0.22621', '10.0.22000', '10.0.20348', '10.0.19041', '10.0.18362', '10.0.17763', '10.0.17134', '10.0.16299', '10.0.15063', '10.0.14393', '10.0.10586', '10.0.10240')]
-    [string]$NtTargetVersion = $(if ([string]::IsNullOrEmpty($env:WDS_NtTargetVersion)) { '10.0.28000' } else { $env:WDS_NtTargetVersion }),
+    # _NT_TARGET_VERSION = the WDK library version the driver links against. Valid values are
+    # auto-discovered from the WDK (Get-NtTargetVersions.ps1); empty = the latest discovered.
+    [string]$NtTargetVersion = $env:WDS_NtTargetVersion,
     [string]$LogFilesDirectory = (Join-Path (Get-Location) "_logs"),
     [string]$ReportFileName = $(if ([string]::IsNullOrEmpty($env:WDS_ReportFileName)) { "_overview" } else { $env:WDS_ReportFileName }),
     [string]$InfOptions,
@@ -131,24 +119,18 @@ function Import-SampleExclusions {
           - Reason:         human-readable explanation
 
         A row is only returned when ALL of the following match the current build:
-          - its [MinBuild, MaxBuild] range includes the given build number,
+          - its [MinBuild, MaxBuild] range includes the given build number, and
           - its [MinNtTargetVersion, MaxNtTargetVersion] range includes the current
-            _NT_TARGET_VERSION build number (e.g. 22000 parsed from '10.0.22000'), and
-          - its TargetVersions list matches the given TargetVersion. TargetVersions is
-            blank/'*' for all versions, or a ';'-separated list of -like patterns
-            (e.g. 'Windows8', 'Windows7;Windows8', 'Windows*').
-        Rows outside any range, or whose TargetVersions does not match, are skipped.
-        MinBuild/MaxBuild and MinNtTargetVersion/MaxNtTargetVersion are blank = unbounded.
+            _NT_TARGET_VERSION build number (e.g. 22000 parsed from '10.0.22000').
+        Rows outside either range are skipped; blank range bounds mean unbounded.
     .NOTES
-        CSV format:  Path,Configurations,TargetVersions,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
-        Example row:         network\wlan\wdi,*,,,27100,,,"failure introduced in VS17.14"
-        Target-specific:     somepath,*|ARM64,Windows8,,,,,"ARM not supported when targeting Windows 8"
-        NT-version-specific: somepath,*,,,,,22621,"needs an API newer than the 10.0.22621 library"
+        CSV format:  Path,Configurations,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
+        Example row:         network\wlan\wdi,*,26100,,,,"failure introduced in VS17.14"
+        NT-version-specific: somepath,*,,,,22621,"needs an API newer than the 10.0.22621 library"
     #>
     param(
         [string]$CsvPath,
         [int]$BuildNumber,
-        [string]$TargetVersion = 'Windows10',
         [string]$NtTargetVersion = '10.0.28000'
     )
 
@@ -165,22 +147,15 @@ function Import-SampleExclusions {
     Import-Csv $CsvPath | ForEach-Object {
         $pattern  = $_.Path.Trim('\').Replace('\', '.').ToLower()
         $configs  = if ([string]::IsNullOrWhiteSpace($_.Configurations)) { '*' } else { $_.Configurations }
-        # TargetVersions column is optional; blank or missing means "all target versions".
-        $targets  = if ([string]::IsNullOrWhiteSpace($_.TargetVersions)) { '*' } else { $_.TargetVersions }
         $minBuild = if ([string]::IsNullOrWhiteSpace($_.MinBuild)) { 0 }     else { [int]$_.MinBuild }
         $maxBuild = if ([string]::IsNullOrWhiteSpace($_.MaxBuild)) { 99999 } else { [int]$_.MaxBuild }
         # Min/MaxNtTargetVersion columns are optional; blank or missing means "all NT versions".
         $minNt    = if ([string]::IsNullOrWhiteSpace($_.MinNtTargetVersion)) { 0 }       else { [int]$_.MinNtTargetVersion }
         $maxNt    = if ([string]::IsNullOrWhiteSpace($_.MaxNtTargetVersion)) { 9999999 } else { [int]$_.MaxNtTargetVersion }
 
-        # TargetVersion and _NT_TARGET_VERSION are constant for the whole run, so (like the
-        # build number) filter these rows out here at load time.
-        $targetMatches = $targets.Split(';') | Where-Object { $TargetVersion -like $_.Trim() }
-
-        if (-not $targetMatches) {
-            Write-Verbose "Exclusion skipped: '$pattern' - target '$TargetVersion' not in '$targets'"
-        }
-        elseif ($ntBuild -lt $minNt -or $ntBuild -gt $maxNt) {
+        # _NT_TARGET_VERSION is constant for the whole run, so (like the build number) filter
+        # these rows out here at load time.
+        if ($ntBuild -lt $minNt -or $ntBuild -gt $maxNt) {
             Write-Verbose "Exclusion skipped: '$pattern' - _NT_TARGET_VERSION $ntBuild outside [$minNt, $maxNt]"
         }
         elseif ($minBuild -le $BuildNumber -and $BuildNumber -le $maxBuild) {
@@ -189,7 +164,7 @@ function Import-SampleExclusions {
                 Configurations = $configs
                 Reason         = $_.Reason
             })
-            Write-Verbose "Exclusion applied: '$pattern' configs='$configs' targets='$targets' ntRange=[$minNt,$maxNt] reason='$($_.Reason)'"
+            Write-Verbose "Exclusion applied: '$pattern' configs='$configs' ntRange=[$minNt,$maxNt] reason='$($_.Reason)'"
         }
         else {
             Write-Verbose "Exclusion skipped: '$pattern' - build $BuildNumber outside [$minBuild, $maxBuild]"
@@ -230,7 +205,6 @@ function Build-SingleSample {
         [string]$SampleName,
         [string]$Configuration = 'Debug',
         [string]$Platform = 'x64',
-        [string]$TargetVersion = 'Windows10',
         [string]$NtTargetVersionCode = '0xA000012',
         [string]$InfVerif_AdditionalOptions = '/samples',
         [string]$LogFilesDirectory = (Get-Location),
@@ -308,7 +282,7 @@ function Build-SingleSample {
             -clp:Verbosity=m -t:rebuild `
             -property:Configuration=$Configuration `
             -property:Platform=$Platform `
-            -p:TargetVersion=$TargetVersion `
+            -p:TargetVersion=Windows10 `
             -p:_NT_TARGET_VERSION=$NtTargetVersionCode `
             -p:InfVerif_AdditionalOptions="$InfVerif_AdditionalOptions" `
             -warnaserror `
@@ -454,26 +428,36 @@ else {
 }
 
 # =============================================================================
-#  Step 5b - Resolve _NT_TARGET_VERSION code
+#  Step 5b - Resolve _NT_TARGET_VERSION
 # =============================================================================
 #
-# _NT_TARGET_VERSION selects the WDK library version the driver links against
-# (independent of the Target OS Version). The MSBuild property takes the NTDDI hex
-# code, so map the friendly build number to it. Codes come from WDK DriverGeneral.xml.
-$ntTargetVersionCodes = [ordered]@{
-    '10.0.28000' = '0xA000012'; '10.0.26100' = '0xA000010'; '10.0.22621' = '0xA00000C'
-    '10.0.22000' = '0xA00000B'; '10.0.20348' = '0xA00000A'; '10.0.19041' = '0xA000008'
-    '10.0.18362' = '0xA000007'; '10.0.17763' = '0xA000006'; '10.0.17134' = '0xA000005'
-    '10.0.16299' = '0xA000004'; '10.0.15063' = '0xA000003'; '10.0.14393' = '0xA000002'
-    '10.0.10586' = '0xA000001'; '10.0.10240' = '0x0A00'
+# _NT_TARGET_VERSION selects the WDK library version the driver links against. The valid
+# values (and their NTDDI codes) are auto-discovered from the active WDK by
+# Get-NtTargetVersions.ps1, so nothing here needs updating when a new WDK version ships.
+# msbuild takes the NTDDI code.
+$ntVersions = & (Join-Path $PSScriptRoot 'Get-NtTargetVersions.ps1')
+if (-not $ntVersions) {
+    Write-Error "Could not discover any _NT_TARGET_VERSION values from the active WDK."
+    exit 1
 }
-$ntTargetVersionCode = $ntTargetVersionCodes[$NtTargetVersion]
+if ([string]::IsNullOrWhiteSpace($NtTargetVersion) -or $NtTargetVersion -eq 'latest') {
+    $ntSelected = $ntVersions[0]      # newest
+}
+else {
+    $ntSelected = $ntVersions | Where-Object { $_.Version -eq $NtTargetVersion -or $_.Tag -eq $NtTargetVersion } | Select-Object -First 1
+    if (-not $ntSelected) {
+        Write-Error "Invalid -NtTargetVersion '$NtTargetVersion'. Valid values: $(($ntVersions.Version) -join ', ')"
+        exit 1
+    }
+}
+$NtTargetVersion     = $ntSelected.Version
+$ntTargetVersionCode = $ntSelected.Code
 
 # =============================================================================
 #  Step 6 - Load Exclusions
 # =============================================================================
 
-$exclusions = Import-SampleExclusions -CsvPath (Join-Path $root 'exclusions.csv') -BuildNumber $buildNumber -TargetVersion $TargetVersion -NtTargetVersion $NtTargetVersion
+$exclusions = Import-SampleExclusions -CsvPath (Join-Path $root 'exclusions.csv') -BuildNumber $buildNumber -NtTargetVersion $NtTargetVersion
 
 # =============================================================================
 #  Step 7 - Print Build Plan
@@ -494,7 +478,6 @@ Write-Output ""
 Write-Output "  Samples:          $($sampleSet.Count) ($skippedCount skipped)"
 Write-Output "  Configurations:   $($Configurations -join ', ')"
 Write-Output "  Platforms:        $($Platforms -join ', ')"
-Write-Output "  Target Version:   $TargetVersion"
 Write-Output "  NT Target Ver:    $NtTargetVersion ($ntTargetVersionCode)"
 Write-Output "  Combinations:     $combinationsTotal"
 Write-Output "  Exclusions:       $($exclusions.Count)"
@@ -542,7 +525,6 @@ $sampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
     $configs    = $using:Configurations
     $platforms  = $using:Platforms
     $infOpts    = $using:infVerifOptions
-    $targetVer  = $using:TargetVersion
     $ntCode     = $using:ntTargetVersionCode
     $isVerbose  = $using:verbose
     $state      = $using:buildState
@@ -594,8 +576,7 @@ $sampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
                 $buildResult = Build-SingleSample `
                     -Directory $directory -SampleName $sampleName `
                     -LogFilesDirectory $logDir -Configuration $configuration `
-                    -Platform $platform -TargetVersion $targetVer `
-                    -NtTargetVersionCode $ntCode `
+                    -Platform $platform -NtTargetVersionCode $ntCode `
                     -InfVerif_AdditionalOptions $infOpts `
                     -Verbose:$isVerbose
 
@@ -714,7 +695,6 @@ Write-Output ""
 Write-Output "  Samples:          $($sampleSet.Count)"
 Write-Output "  Configurations:   $($Configurations -join ', ')"
 Write-Output "  Platforms:        $($Platforms -join ', ')"
-Write-Output "  Target Version:   $TargetVersion"
 Write-Output "  NT Target Ver:    $NtTargetVersion ($ntTargetVersionCode)"
 Write-Output "  Combinations:     $combinationsTotal"
 Write-Output ""
@@ -735,7 +715,7 @@ Write-Output "------------------------------------------------------------------
 
 $sortedResults = $buildState.Results | Sort-Object { $_.Sample }
 $sortedResults | ConvertTo-Csv  | Out-File $reportCsvPath
-$sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview - TargetVersion $TargetVersion, _NT_TARGET_VERSION $NtTargetVersion" | Out-File $reportHtmlPath
+$sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview - _NT_TARGET_VERSION $NtTargetVersion" | Out-File $reportHtmlPath
 
 # Only open the HTML report interactively (not in CI/automation)
 if (-not $env:BUILD_BUILDID -and [Environment]::UserInteractive) {
@@ -755,7 +735,7 @@ if ($env:GITHUB_STEP_SUMMARY) {
     $md = [System.Text.StringBuilder]::new()
     [void]$md.AppendLine("## $icon ``$cfgLabel`` &nbsp;&middot;&nbsp; _NT_TARGET_VERSION ``$NtTargetVersion``")
     [void]$md.AppendLine()
-    [void]$md.AppendLine("Environment **$($buildEnv.Name)** &middot; WDK build **$buildNumber** &middot; TargetVersion **$TargetVersion** &middot; **$($sampleSet.Count)** samples &middot; $($elapsed.Minutes)m $($elapsed.Seconds)s")
+    [void]$md.AppendLine("Environment **$($buildEnv.Name)** &middot; WDK build **$buildNumber** &middot; **$($sampleSet.Count)** samples &middot; $($elapsed.Minutes)m $($elapsed.Seconds)s")
     [void]$md.AppendLine()
     [void]$md.AppendLine("| :white_check_mark: Succeeded | :x: Failed | :warning: Sporadic | :heavy_minus_sign: Excluded | :grey_question: Unsupported |")
     [void]$md.AppendLine("|---:|---:|---:|---:|---:|")

--- a/Build-Samples.ps1
+++ b/Build-Samples.ps1
@@ -36,6 +36,13 @@
       Windows7     - Windows 7
     Defaults to $env:WDS_TargetVersion, or 'Windows10' (the latest) when unset.
 
+.PARAMETER NtTargetVersion
+    The _NT_TARGET_VERSION value - the WDK library version the driver links against
+    ("OS version of libraries"), which is independent of the Target OS Version. Accepts the
+    Windows build-number form (e.g. '10.0.28000'); valid values come from the WDK
+    DriverGeneral.xml rule and are listed newest-first. Defaults to $env:WDS_NtTargetVersion,
+    or '10.0.28000' (the latest) when unset.
+
 .PARAMETER LogFilesDirectory
     Directory for build log files. Defaults to _logs in the current directory.
 
@@ -95,6 +102,10 @@ param(
     # Valid TargetVersion values come from the WDK DriverGeneral.xml rule (newest first).
     [ValidateSet('Windows10', 'WindowsV6.3', 'Windows8', 'Windows7')]
     [string]$TargetVersion = $(if ([string]::IsNullOrEmpty($env:WDS_TargetVersion)) { 'Windows10' } else { $env:WDS_TargetVersion }),
+    # _NT_TARGET_VERSION = the WDK library version the driver links against (newest first;
+    # values come from the WDK DriverGeneral.xml rule). Default is the latest.
+    [ValidateSet('10.0.28000', '10.0.26100', '10.0.22621', '10.0.22000', '10.0.20348', '10.0.19041', '10.0.18362', '10.0.17763', '10.0.17134', '10.0.16299', '10.0.15063', '10.0.14393', '10.0.10586', '10.0.10240')]
+    [string]$NtTargetVersion = $(if ([string]::IsNullOrEmpty($env:WDS_NtTargetVersion)) { '10.0.28000' } else { $env:WDS_NtTargetVersion }),
     [string]$LogFilesDirectory = (Join-Path (Get-Location) "_logs"),
     [string]$ReportFileName = $(if ([string]::IsNullOrEmpty($env:WDS_ReportFileName)) { "_overview" } else { $env:WDS_ReportFileName }),
     [string]$InfOptions,
@@ -204,6 +215,7 @@ function Build-SingleSample {
         [string]$Configuration = 'Debug',
         [string]$Platform = 'x64',
         [string]$TargetVersion = 'Windows10',
+        [string]$NtTargetVersionCode = '0xA000012',
         [string]$InfVerif_AdditionalOptions = '/samples',
         [string]$LogFilesDirectory = (Get-Location),
         [bool]$Verbose = $false
@@ -281,6 +293,7 @@ function Build-SingleSample {
             -property:Configuration=$Configuration `
             -property:Platform=$Platform `
             -p:TargetVersion=$TargetVersion `
+            -p:_NT_TARGET_VERSION=$NtTargetVersionCode `
             -p:InfVerif_AdditionalOptions="$InfVerif_AdditionalOptions" `
             -warnaserror `
             -binaryLogger:LogFile=$binLogFilePath`;ProjectImports=None `
@@ -425,6 +438,22 @@ else {
 }
 
 # =============================================================================
+#  Step 5b - Resolve _NT_TARGET_VERSION code
+# =============================================================================
+#
+# _NT_TARGET_VERSION selects the WDK library version the driver links against
+# (independent of the Target OS Version). The MSBuild property takes the NTDDI hex
+# code, so map the friendly build number to it. Codes come from WDK DriverGeneral.xml.
+$ntTargetVersionCodes = [ordered]@{
+    '10.0.28000' = '0xA000012'; '10.0.26100' = '0xA000010'; '10.0.22621' = '0xA00000C'
+    '10.0.22000' = '0xA00000B'; '10.0.20348' = '0xA00000A'; '10.0.19041' = '0xA000008'
+    '10.0.18362' = '0xA000007'; '10.0.17763' = '0xA000006'; '10.0.17134' = '0xA000005'
+    '10.0.16299' = '0xA000004'; '10.0.15063' = '0xA000003'; '10.0.14393' = '0xA000002'
+    '10.0.10586' = '0xA000001'; '10.0.10240' = '0x0A00'
+}
+$ntTargetVersionCode = $ntTargetVersionCodes[$NtTargetVersion]
+
+# =============================================================================
 #  Step 6 - Load Exclusions
 # =============================================================================
 
@@ -450,6 +479,7 @@ Write-Output "  Samples:          $($sampleSet.Count) ($skippedCount skipped)"
 Write-Output "  Configurations:   $($Configurations -join ', ')"
 Write-Output "  Platforms:        $($Platforms -join ', ')"
 Write-Output "  Target Version:   $TargetVersion"
+Write-Output "  NT Target Ver:    $NtTargetVersion ($ntTargetVersionCode)"
 Write-Output "  Combinations:     $combinationsTotal"
 Write-Output "  Exclusions:       $($exclusions.Count)"
 Write-Output ""
@@ -497,6 +527,7 @@ $sampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
     $platforms  = $using:Platforms
     $infOpts    = $using:infVerifOptions
     $targetVer  = $using:TargetVersion
+    $ntCode     = $using:ntTargetVersionCode
     $isVerbose  = $using:verbose
     $state      = $using:buildState
     $total      = $using:combinationsTotal
@@ -548,6 +579,7 @@ $sampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
                     -Directory $directory -SampleName $sampleName `
                     -LogFilesDirectory $logDir -Configuration $configuration `
                     -Platform $platform -TargetVersion $targetVer `
+                    -NtTargetVersionCode $ntCode `
                     -InfVerif_AdditionalOptions $infOpts `
                     -Verbose:$isVerbose
 
@@ -667,6 +699,7 @@ Write-Output "  Samples:          $($sampleSet.Count)"
 Write-Output "  Configurations:   $($Configurations -join ', ')"
 Write-Output "  Platforms:        $($Platforms -join ', ')"
 Write-Output "  Target Version:   $TargetVersion"
+Write-Output "  NT Target Ver:    $NtTargetVersion ($ntTargetVersionCode)"
 Write-Output "  Combinations:     $combinationsTotal"
 Write-Output ""
 Write-Output "  Succeeded:        $($buildState.Succeeded)"
@@ -686,7 +719,7 @@ Write-Output "------------------------------------------------------------------
 
 $sortedResults = $buildState.Results | Sort-Object { $_.Sample }
 $sortedResults | ConvertTo-Csv  | Out-File $reportCsvPath
-$sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview - TargetVersion $TargetVersion" | Out-File $reportHtmlPath
+$sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview - TargetVersion $TargetVersion, _NT_TARGET_VERSION $NtTargetVersion" | Out-File $reportHtmlPath
 
 # Only open the HTML report interactively (not in CI/automation)
 if (-not $env:BUILD_BUILDID -and [Environment]::UserInteractive) {

--- a/Build-Samples.ps1
+++ b/Build-Samples.ps1
@@ -27,6 +27,15 @@
 .PARAMETER Platforms
     Build platforms (e.g. 'x64','arm64'). Defaults to $env:WDS_Platform or ('x64','arm64').
 
+.PARAMETER TargetVersion
+    Target OS version the drivers are built for (the msbuild 'TargetVersion' property).
+    Valid values are defined by the WDK DriverGeneral.xml rule and are listed newest-first:
+      Windows10    - Windows 10 or higher (default, latest)
+      WindowsV6.3  - Windows 8.1
+      Windows8     - Windows 8
+      Windows7     - Windows 7
+    Defaults to $env:WDS_TargetVersion, or 'Windows10' (the latest) when unset.
+
 .PARAMETER LogFilesDirectory
     Directory for build log files. Defaults to _logs in the current directory.
 
@@ -69,6 +78,11 @@
     .\Build-Samples -RunMode WDK
 
     Forces WDK mode regardless of environment variables.
+
+.EXAMPLE
+    .\Build-Samples -TargetVersion Windows7
+
+    Builds all samples targeting Windows 7 instead of the default (latest) Windows10.
 #>
 
 #Requires -Version 7.0
@@ -78,6 +92,9 @@ param(
     [string[]]$Samples,
     [string[]]$Configurations = @(if ([string]::IsNullOrEmpty($env:WDS_Configuration)) { ('Debug', 'Release') } else { $env:WDS_Configuration }),
     [string[]]$Platforms = @(if ([string]::IsNullOrEmpty($env:WDS_Platform)) { ('x64', 'arm64') } else { $env:WDS_Platform }),
+    # Valid TargetVersion values come from the WDK DriverGeneral.xml rule (newest first).
+    [ValidateSet('Windows10', 'WindowsV6.3', 'Windows8', 'Windows7')]
+    [string]$TargetVersion = $(if ([string]::IsNullOrEmpty($env:WDS_TargetVersion)) { 'Windows10' } else { $env:WDS_TargetVersion }),
     [string]$LogFilesDirectory = (Join-Path (Get-Location) "_logs"),
     [string]$ReportFileName = $(if ([string]::IsNullOrEmpty($env:WDS_ReportFileName)) { "_overview" } else { $env:WDS_ReportFileName }),
     [string]$InfOptions,
@@ -172,6 +189,7 @@ function Build-SingleSample {
         [string]$SampleName,
         [string]$Configuration = 'Debug',
         [string]$Platform = 'x64',
+        [string]$TargetVersion = 'Windows10',
         [string]$InfVerif_AdditionalOptions = '/samples',
         [string]$LogFilesDirectory = (Get-Location),
         [bool]$Verbose = $false
@@ -248,7 +266,7 @@ function Build-SingleSample {
             -clp:Verbosity=m -t:rebuild `
             -property:Configuration=$Configuration `
             -property:Platform=$Platform `
-            -p:TargetVersion=Windows10 `
+            -p:TargetVersion=$TargetVersion `
             -p:InfVerif_AdditionalOptions="$InfVerif_AdditionalOptions" `
             -warnaserror `
             -binaryLogger:LogFile=$binLogFilePath`;ProjectImports=None `
@@ -417,6 +435,7 @@ Write-Output ""
 Write-Output "  Samples:          $($sampleSet.Count) ($skippedCount skipped)"
 Write-Output "  Configurations:   $($Configurations -join ', ')"
 Write-Output "  Platforms:        $($Platforms -join ', ')"
+Write-Output "  Target Version:   $TargetVersion"
 Write-Output "  Combinations:     $combinationsTotal"
 Write-Output "  Exclusions:       $($exclusions.Count)"
 Write-Output ""
@@ -463,6 +482,7 @@ $sampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
     $configs    = $using:Configurations
     $platforms  = $using:Platforms
     $infOpts    = $using:infVerifOptions
+    $targetVer  = $using:TargetVersion
     $isVerbose  = $using:verbose
     $state      = $using:buildState
     $total      = $using:combinationsTotal
@@ -513,7 +533,8 @@ $sampleSet.GetEnumerator() | ForEach-Object -ThrottleLimit $ThrottleLimit -Paral
                 $buildResult = Build-SingleSample `
                     -Directory $directory -SampleName $sampleName `
                     -LogFilesDirectory $logDir -Configuration $configuration `
-                    -Platform $platform -InfVerif_AdditionalOptions $infOpts `
+                    -Platform $platform -TargetVersion $targetVer `
+                    -InfVerif_AdditionalOptions $infOpts `
                     -Verbose:$isVerbose
 
                 # Return codes from Build-SingleSample:
@@ -631,6 +652,7 @@ Write-Output ""
 Write-Output "  Samples:          $($sampleSet.Count)"
 Write-Output "  Configurations:   $($Configurations -join ', ')"
 Write-Output "  Platforms:        $($Platforms -join ', ')"
+Write-Output "  Target Version:   $TargetVersion"
 Write-Output "  Combinations:     $combinationsTotal"
 Write-Output ""
 Write-Output "  Succeeded:        $($buildState.Succeeded)"
@@ -650,7 +672,7 @@ Write-Output "------------------------------------------------------------------
 
 $sortedResults = $buildState.Results | Sort-Object { $_.Sample }
 $sortedResults | ConvertTo-Csv  | Out-File $reportCsvPath
-$sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview" | Out-File $reportHtmlPath
+$sortedResults | ConvertTo-Html -Title "WDK Sample Build Overview - TargetVersion $TargetVersion" | Out-File $reportHtmlPath
 
 # Only open the HTML report interactively (not in CI/automation)
 if (-not $env:BUILD_BUILDID -and [Environment]::UserInteractive) {

--- a/Building-Locally.md
+++ b/Building-Locally.md
@@ -123,6 +123,9 @@ Get-Help .\Build-Samples.ps1 -Detailed
 
 # Build every sample targeting an older OS version (default is the latest, Windows10):
 .\Build-Samples.ps1 -TargetVersion Windows7
+
+# Build every sample linking against an older WDK library set (default is the latest):
+.\Build-Samples.ps1 -NtTargetVersion 10.0.22000
 ```
 
 The `-TargetVersion` values come from the WDK `DriverGeneral.xml` rule and are listed
@@ -134,6 +137,20 @@ newest-first. The default is the latest, `Windows10`:
 | `WindowsV6.3` | Windows 8.1            |
 | `Windows8`    | Windows 8              |
 | `Windows7`    | Windows 7              |
+
+`-TargetVersion` (Target OS Version) selects the driver's *platform model* and is gated to
+Windows 10+ for Universal / Windows Driver samples. To instead vary the **library version the
+driver links against** - the WDK's `_NT_TARGET_VERSION` ("OS version of libraries") - while
+keeping the platform on Windows 10, use `-NtTargetVersion`. It accepts a Windows build number;
+values come from the WDK `DriverGeneral.xml` rule (newest-first), default latest `10.0.28000`:
+
+| `-NtTargetVersion` | Links against     |
+| ------------------ | ----------------- |
+| `10.0.28000`       | latest (default)  |
+| `10.0.26100`       | 24H2              |
+| `10.0.22621`       | 22H2              |
+| `10.0.22000`       | 21H2              |
+| ...                | down to `10.0.10240` |
 
 ---
 

--- a/Building-Locally.md
+++ b/Building-Locally.md
@@ -121,36 +121,20 @@ Get-Help .\Build-Samples.ps1 -Detailed
 # Build a specific sample for Debug|x64 only:
 .\Build-Samples.ps1 -Samples 'tools.sdv.samples.sampledriver' -Configurations 'Debug' -Platforms 'x64'
 
-# Build every sample targeting an older OS version (default is the latest, Windows10):
-.\Build-Samples.ps1 -TargetVersion Windows7
-
 # Build every sample linking against an older WDK library set (default is the latest):
 .\Build-Samples.ps1 -NtTargetVersion 10.0.22000
 ```
 
-The `-TargetVersion` values come from the WDK `DriverGeneral.xml` rule and are listed
-newest-first. The default is the latest, `Windows10`:
+`-NtTargetVersion` selects the WDK **`_NT_TARGET_VERSION`** — the OS version of the libraries
+the driver links against. It accepts the Windows build number (`10.0.<build>`) or the short
+`<build>` tag (e.g. `10.0.22000` or `22000`); when omitted it uses the latest. The valid
+values are **auto-discovered from the active WDK** — `Get-NtTargetVersions.ps1` parses the
+WDK's `DriverGeneral.xml` rule — so a new WDK version is picked up automatically with no edits.
+List what's available with:
 
-| Value         | Target OS              |
-| ------------- | ---------------------- |
-| `Windows10`   | Windows 10 or higher (default) |
-| `WindowsV6.3` | Windows 8.1            |
-| `Windows8`    | Windows 8              |
-| `Windows7`    | Windows 7              |
-
-`-TargetVersion` (Target OS Version) selects the driver's *platform model* and is gated to
-Windows 10+ for Universal / Windows Driver samples. To instead vary the **library version the
-driver links against** - the WDK's `_NT_TARGET_VERSION` ("OS version of libraries") - while
-keeping the platform on Windows 10, use `-NtTargetVersion`. It accepts a Windows build number;
-values come from the WDK `DriverGeneral.xml` rule (newest-first), default latest `10.0.28000`:
-
-| `-NtTargetVersion` | Links against     |
-| ------------------ | ----------------- |
-| `10.0.28000`       | latest (default)  |
-| `10.0.26100`       | 24H2              |
-| `10.0.22621`       | 22H2              |
-| `10.0.22000`       | 21H2              |
-| ...                | down to `10.0.10240` |
+```powershell
+.\Get-NtTargetVersions.ps1
+```
 
 ---
 
@@ -159,36 +143,29 @@ values come from the WDK `DriverGeneral.xml` rule (newest-first), default latest
 Samples that are known not to build for a given environment are listed in `exclusions.csv`
 at the repo root. Each row excludes a path (with wildcards) for specific
 configuration/platform combinations, an optional WDK build-number range, and an optional
-set of target versions:
+`_NT_TARGET_VERSION` range:
 
 ```
-Path,Configurations,TargetVersions,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
+Path,Configurations,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
 ```
 
 | Column           | Meaning                                                                                  |
 | ---------------- | ---------------------------------------------------------------------------------------- |
 | `Path`           | Sample path (backslashes); supports `*`/`?` wildcards.                                    |
 | `Configurations` | `;`-separated `Config\|Platform` patterns, or `*` for all (e.g. `*\|ARM64`, `Debug\|x64`). |
-| `TargetVersions` | `;`-separated `-like` patterns matched against `-TargetVersion`; blank or `*` = all (e.g. `Windows8`, `Windows7;Windows8`, `Windows*`). |
 | `MinBuild`/`MaxBuild` | Inclusive WDK build-number range; blank = unbounded.                                |
 | `MinNtTargetVersion`/`MaxNtTargetVersion` | Inclusive `-NtTargetVersion` build-number range (e.g. `22621` matches `10.0.22621`); blank = unbounded. Use this for samples that fail only when linking against older libraries. |
 | `Reason`         | Human-readable explanation (keep this column last; quote it if it contains commas).      |
 
 A row is applied only when every populated condition matches the current run (path,
-configuration/platform, WDK build-number range, NT target-version range, and target version
-are AND-ed together). Leave a column blank to ignore that dimension (the default for most rows).
+configuration/platform, WDK build-number range, and NT target-version range are AND-ed
+together). Leave a column blank to ignore that dimension (the default for most rows).
 
-For example, to exclude all ARM platforms only when building for Windows 8:
-
-```
-somepath,*|ARM64,Windows8,,,,,"ARM not supported when targeting Windows 8"
-```
-
-Or to exclude a sample (Debug builds only) when linking against the `10.0.22621` library set
-or older, because it uses a newer API:
+For example, to exclude a sample (Debug builds only) when linking against the `10.0.22621`
+library set or older, because it uses a newer API:
 
 ```
-somepath,Debug|*,,,,,22621,uses an API newer than the 10.0.22621 library
+somepath,Debug|*,,,,22621,uses an API newer than the 10.0.22621 library
 ```
 
 ---

--- a/Building-Locally.md
+++ b/Building-Locally.md
@@ -162,7 +162,7 @@ configuration/platform combinations, an optional WDK build-number range, and an 
 set of target versions:
 
 ```
-Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
+Path,Configurations,TargetVersions,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
 ```
 
 | Column           | Meaning                                                                                  |
@@ -171,16 +171,24 @@ Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
 | `Configurations` | `;`-separated `Config\|Platform` patterns, or `*` for all (e.g. `*\|ARM64`, `Debug\|x64`). |
 | `TargetVersions` | `;`-separated `-like` patterns matched against `-TargetVersion`; blank or `*` = all (e.g. `Windows8`, `Windows7;Windows8`, `Windows*`). |
 | `MinBuild`/`MaxBuild` | Inclusive WDK build-number range; blank = unbounded.                                |
+| `MinNtTargetVersion`/`MaxNtTargetVersion` | Inclusive `-NtTargetVersion` build-number range (e.g. `22621` matches `10.0.22621`); blank = unbounded. Use this for samples that fail only when linking against older libraries. |
 | `Reason`         | Human-readable explanation (keep this column last; quote it if it contains commas).      |
 
 A row is applied only when every populated condition matches the current run (path,
-configuration/platform, build-number range, and target version are AND-ed together). Leave
-`TargetVersions` blank to exclude regardless of target version (the default for most rows).
+configuration/platform, WDK build-number range, NT target-version range, and target version
+are AND-ed together). Leave a column blank to ignore that dimension (the default for most rows).
 
 For example, to exclude all ARM platforms only when building for Windows 8:
 
 ```
-somepath,*|ARM64,Windows8,,,"ARM not supported when targeting Windows 8"
+somepath,*|ARM64,Windows8,,,,,"ARM not supported when targeting Windows 8"
+```
+
+Or to exclude a sample (Debug builds only) when linking against the `10.0.22621` library set
+or older, because it uses a newer API:
+
+```
+somepath,Debug|*,,,,,22621,uses an API newer than the 10.0.22621 library
 ```
 
 ---

--- a/Building-Locally.md
+++ b/Building-Locally.md
@@ -137,6 +137,37 @@ newest-first. The default is the latest, `Windows10`:
 
 ---
 
+## Excluding samples from the build
+
+Samples that are known not to build for a given environment are listed in `exclusions.csv`
+at the repo root. Each row excludes a path (with wildcards) for specific
+configuration/platform combinations, an optional WDK build-number range, and an optional
+set of target versions:
+
+```
+Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
+```
+
+| Column           | Meaning                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| `Path`           | Sample path (backslashes); supports `*`/`?` wildcards.                                    |
+| `Configurations` | `;`-separated `Config\|Platform` patterns, or `*` for all (e.g. `*\|ARM64`, `Debug\|x64`). |
+| `TargetVersions` | `;`-separated `-like` patterns matched against `-TargetVersion`; blank or `*` = all (e.g. `Windows8`, `Windows7;Windows8`, `Windows*`). |
+| `MinBuild`/`MaxBuild` | Inclusive WDK build-number range; blank = unbounded.                                |
+| `Reason`         | Human-readable explanation (keep this column last; quote it if it contains commas).      |
+
+A row is applied only when every populated condition matches the current run (path,
+configuration/platform, build-number range, and target version are AND-ed together). Leave
+`TargetVersions` blank to exclude regardless of target version (the default for most rows).
+
+For example, to exclude all ARM platforms only when building for Windows 8:
+
+```
+somepath,*|ARM64,Windows8,,,"ARM not supported when targeting Windows 8"
+```
+
+---
+
 ## Additional Notes
 
 ### Pre-release WDK: disable strong name validation

--- a/Building-Locally.md
+++ b/Building-Locally.md
@@ -120,7 +120,20 @@ Get-Help .\Build-Samples.ps1 -Detailed
 
 # Build a specific sample for Debug|x64 only:
 .\Build-Samples.ps1 -Samples 'tools.sdv.samples.sampledriver' -Configurations 'Debug' -Platforms 'x64'
+
+# Build every sample targeting an older OS version (default is the latest, Windows10):
+.\Build-Samples.ps1 -TargetVersion Windows7
 ```
+
+The `-TargetVersion` values come from the WDK `DriverGeneral.xml` rule and are listed
+newest-first. The default is the latest, `Windows10`:
+
+| Value         | Target OS              |
+| ------------- | ---------------------- |
+| `Windows10`   | Windows 10 or higher (default) |
+| `WindowsV6.3` | Windows 8.1            |
+| `Windows8`    | Windows 8              |
+| `Windows7`    | Windows 7              |
 
 ---
 

--- a/Get-NtTargetVersions.ps1
+++ b/Get-NtTargetVersions.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Auto-discovers the valid _NT_TARGET_VERSION values from the active WDK.
+
+.DESCRIPTION
+    The _NT_TARGET_VERSION property (the OS version of the libraries a driver links against)
+    is an enumeration defined by the WDK in its 'DriverGeneral.xml' rule file. This script
+    locates that rule file (from the restored NuGet packages, or the installed WDK) and parses
+    the enumeration so that nothing in the build needs a hard-coded version list: when a new
+    WDK adds a new _NT_TARGET_VERSION it is picked up automatically.
+
+    Returns one object per Windows 10/11 entry, newest-first:
+        Version  e.g. 10.0.28000   (use with -NtTargetVersion)
+        Tag      e.g. 28000        (short, filename/CI-friendly)
+        Code     e.g. 0xA000012    (the NTDDI value passed to msbuild)
+        Build    e.g. 28000        (numeric, for sorting/ranges)
+
+.PARAMETER XmlPath
+    Optional explicit path to a DriverGeneral.xml. When omitted the newest available rule file
+    is auto-located.
+
+.PARAMETER Newest
+    Return only the newest N versions (0 = all). Useful for bounding the CI build matrix.
+
+.PARAMETER AsMatrixJson
+    Emit a compact JSON array of { version, tag } objects for a GitHub Actions matrix
+    (consumed via fromJSON). Implies a single-line output.
+
+.EXAMPLE
+    .\Get-NtTargetVersions.ps1                  # all discovered versions (objects)
+
+.EXAMPLE
+    .\Get-NtTargetVersions.ps1 -Newest 4 -AsMatrixJson
+#>
+[CmdletBinding()]
+param(
+    [string]$XmlPath,
+    [int]$Newest = 0,
+    [switch]$AsMatrixJson
+)
+
+function Find-DriverGeneralXml {
+    # Prefer the restored NuGet WDK package (matches what the build actually uses), then the
+    # installed WDK. Within each source, pick the highest build version.
+    $candidates = @()
+    $candidates += Get-ChildItem -Path (Join-Path $PSScriptRoot 'packages') -Recurse -Filter 'DriverGeneral.xml' -ErrorAction SilentlyContinue
+    foreach ($kitsRoot in @("${env:ProgramFiles(x86)}\Windows Kits\10\build", "${env:ProgramFiles}\Windows Kits\10\build")) {
+        if ($kitsRoot -and (Test-Path $kitsRoot)) {
+            $candidates += Get-ChildItem -Path $kitsRoot -Recurse -Filter 'DriverGeneral.xml' -ErrorAction SilentlyContinue
+        }
+    }
+    # EWDK / arbitrary build environments expose the build tree via these variables.
+    foreach ($envRoot in @($env:WDKContentRoot, $env:WindowsSdkDir)) {
+        if ($envRoot -and (Test-Path $envRoot)) {
+            $buildDir = Join-Path $envRoot 'build'
+            if (Test-Path $buildDir) {
+                $candidates += Get-ChildItem -Path $buildDir -Recurse -Filter 'DriverGeneral.xml' -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    if (-not $candidates) { return $null }
+    # Order by the build version embedded in the path (e.g. ...\10.0.28000.0\...), highest first.
+    return ($candidates | Sort-Object {
+            if ($_.FullName -match '10\.0\.(\d+)\.\d') { [int]$Matches[1] } else { 0 }
+        } -Descending | Select-Object -First 1).FullName
+}
+
+if (-not $XmlPath) { $XmlPath = Find-DriverGeneralXml }
+if (-not $XmlPath -or -not (Test-Path $XmlPath)) {
+    throw "Could not locate DriverGeneral.xml. Restore the WDK NuGet packages or install the WDK, or pass -XmlPath."
+}
+
+[xml]$xml = Get-Content -Path $XmlPath -Raw
+$enum = $xml.ProjectSchemaDefinitions.Rule.EnumProperty | Where-Object { $_.Name -eq '_NT_TARGET_VERSION' }
+if (-not $enum) { throw "No _NT_TARGET_VERSION enumeration found in '$XmlPath'." }
+
+$versions =
+    $enum.EnumValue |
+    ForEach-Object {
+        # DisplayName is e.g. "Windows 10.0.28000"; Name is the NTDDI code e.g. "0xA000012".
+        if ("$($_.DisplayName)" -match 'Windows\s+(?<v>10\.0\.(?<b>\d+))\s*$') {
+            [pscustomobject]@{
+                Version = $Matches.v
+                Tag     = $Matches.b
+                Code    = $_.Name
+                Build   = [int]$Matches.b
+            }
+        }
+    } |
+    Sort-Object Build -Descending
+
+if ($Newest -gt 0) { $versions = $versions | Select-Object -First $Newest }
+
+if ($AsMatrixJson) {
+    # Compact, single-line JSON for a GitHub Actions matrix: [{ "version": "...", "tag": "..." }, ...]
+    $matrix = @($versions | ForEach-Object { [ordered]@{ version = $_.Version; tag = $_.Tag } })
+    return ($matrix | ConvertTo-Json -Compress -Depth 3)
+}
+
+return $versions

--- a/exclusions.csv
+++ b/exclusions.csv
@@ -1,20 +1,20 @@
-Path,Configurations,TargetVersions,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
-audio\acx\samples\audiocodec\driver,*,,,22621,,,Only NI: error C1083: Cannot open include file: 'acx.h': No such file or directory
-general\dchu\osrfx2_dchu_extension_loose,*|x64,,,22621,,,Only NI: Only x64: Fails to build
-general\dchu\osrfx2_dchu_extension_tight,*|x64,,,22621,,,Only NI: Only x64: Fails to build
-network\trans\WFPSampler,Debug|ARM64,,,22621,,,Only NI: Only ARM: Fails to build on EWDK 22621 with VS 17.1.5 - CallingConvention=StdCall not supported
-prm,*,,,22621,,,Only NI: Not supported on NI.
-powerlimit\plclient,*,,,22621,,,Only NI: Not supported on NI.
-powerlimit\plpolicy,*,,,22621,,,Only NI: Not supported on NI.
-general\pcidrv,*,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
-serial\serial,*,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
-network\wlan\wdi,*,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
-tools\kasan\samples\kasandemo-wdm,*|x64,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
-audio\sysvad,*,,,,,22000,_NT_TARGET_VERSION: KSJACK_DESCRIPTION3 undeclared; audio jack descriptor v3 was added in 22H2 (10.0.22621)
-network\netadaptercx\netvadapter,*,,,,,22621,_NT_TARGET_VERSION: requests an NDIS/DDI version newer than the linked library (C1189 wrong NDIS or DDI version)
-network\wlan\wificx,*,,,,,22621,_NT_TARGET_VERSION: requests an NDIS/DDI version newer than the linked library (C1189 wrong NDIS or DDI version)
-powerlimit\plclient,*,,,,,22621,_NT_TARGET_VERSION: POWER_LIMIT_ATTRIBUTES not declared in the older library (C2061)
-powerlimit\plpolicy,*,,,,,22621,_NT_TARGET_VERSION: POWER_LIMIT_ATTRIBUTES not declared in the older library (C2061)
-storage\class\classpnp,Debug|*,,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug only
-storage\miniports\storahci,Debug|*,,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug only
-storage\msdsm,Debug|x64,,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug|x64 only
+Path,Configurations,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
+audio\acx\samples\audiocodec\driver,*,,22621,,,Only NI: error C1083: Cannot open include file: 'acx.h': No such file or directory
+general\dchu\osrfx2_dchu_extension_loose,*|x64,,22621,,,Only NI: Only x64: Fails to build
+general\dchu\osrfx2_dchu_extension_tight,*|x64,,22621,,,Only NI: Only x64: Fails to build
+network\trans\WFPSampler,Debug|ARM64,,22621,,,Only NI: Only ARM: Fails to build on EWDK 22621 with VS 17.1.5 - CallingConvention=StdCall not supported
+prm,*,,22621,,,Only NI: Not supported on NI.
+powerlimit\plclient,*,,22621,,,Only NI: Not supported on NI.
+powerlimit\plpolicy,*,,22621,,,Only NI: Not supported on NI.
+general\pcidrv,*,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+serial\serial,*,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+network\wlan\wdi,*,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+tools\kasan\samples\kasandemo-wdm,*|x64,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+audio\sysvad,*,,,,22000,_NT_TARGET_VERSION: KSJACK_DESCRIPTION3 undeclared; audio jack descriptor v3 was added in 22H2 (10.0.22621)
+network\netadaptercx\netvadapter,*,,,,22621,_NT_TARGET_VERSION: requests an NDIS/DDI version newer than the linked library (C1189 wrong NDIS or DDI version)
+network\wlan\wificx,*,,,,22621,_NT_TARGET_VERSION: requests an NDIS/DDI version newer than the linked library (C1189 wrong NDIS or DDI version)
+powerlimit\plclient,*,,,,22621,_NT_TARGET_VERSION: POWER_LIMIT_ATTRIBUTES not declared in the older library (C2061)
+powerlimit\plpolicy,*,,,,22621,_NT_TARGET_VERSION: POWER_LIMIT_ATTRIBUTES not declared in the older library (C2061)
+storage\class\classpnp,Debug|*,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug only
+storage\miniports\storahci,Debug|*,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug only
+storage\msdsm,Debug|x64,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug|x64 only

--- a/exclusions.csv
+++ b/exclusions.csv
@@ -1,12 +1,12 @@
-Path,Configurations,MinBuild,MaxBuild,Reason
-audio\acx\samples\audiocodec\driver,*,,22621,Only NI: error C1083: Cannot open include file: 'acx.h': No such file or directory
-general\dchu\osrfx2_dchu_extension_loose,*|x64,,22621,Only NI: Only x64: Fails to build
-general\dchu\osrfx2_dchu_extension_tight,*|x64,,22621,Only NI: Only x64: Fails to build
-network\trans\WFPSampler,Debug|ARM64,,22621,Only NI: Only ARM: Fails to build on EWDK 22621 with VS 17.1.5 - CallingConvention=StdCall not supported
-prm,*,,22621,Only NI: Not supported on NI.
-powerlimit\plclient,*,,22621,Only NI: Not supported on NI.
-powerlimit\plpolicy,*,,22621,Only NI: Not supported on NI.
-general\pcidrv,*,26100,,"failure introduced in VS17.14, suppressed until fix"
-serial\serial,*,26100,,"failure introduced in VS17.14, suppressed until fix"
-network\wlan\wdi,*,26100,,"failure introduced in VS17.14, suppressed until fix"
-tools\kasan\samples\kasandemo-wdm,*|x64,26100,,"failure introduced in VS17.14, suppressed until fix"
+Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
+audio\acx\samples\audiocodec\driver,*,,,22621,Only NI: error C1083: Cannot open include file: 'acx.h': No such file or directory
+general\dchu\osrfx2_dchu_extension_loose,*|x64,,,22621,Only NI: Only x64: Fails to build
+general\dchu\osrfx2_dchu_extension_tight,*|x64,,,22621,Only NI: Only x64: Fails to build
+network\trans\WFPSampler,Debug|ARM64,,,22621,Only NI: Only ARM: Fails to build on EWDK 22621 with VS 17.1.5 - CallingConvention=StdCall not supported
+prm,*,,,22621,Only NI: Not supported on NI.
+powerlimit\plclient,*,,,22621,Only NI: Not supported on NI.
+powerlimit\plpolicy,*,,,22621,Only NI: Not supported on NI.
+general\pcidrv,*,,26100,,"failure introduced in VS17.14, suppressed until fix"
+serial\serial,*,,26100,,"failure introduced in VS17.14, suppressed until fix"
+network\wlan\wdi,*,,26100,,"failure introduced in VS17.14, suppressed until fix"
+tools\kasan\samples\kasandemo-wdm,*|x64,,26100,,"failure introduced in VS17.14, suppressed until fix"

--- a/exclusions.csv
+++ b/exclusions.csv
@@ -1,12 +1,20 @@
-Path,Configurations,TargetVersions,MinBuild,MaxBuild,Reason
-audio\acx\samples\audiocodec\driver,*,,,22621,Only NI: error C1083: Cannot open include file: 'acx.h': No such file or directory
-general\dchu\osrfx2_dchu_extension_loose,*|x64,,,22621,Only NI: Only x64: Fails to build
-general\dchu\osrfx2_dchu_extension_tight,*|x64,,,22621,Only NI: Only x64: Fails to build
-network\trans\WFPSampler,Debug|ARM64,,,22621,Only NI: Only ARM: Fails to build on EWDK 22621 with VS 17.1.5 - CallingConvention=StdCall not supported
-prm,*,,,22621,Only NI: Not supported on NI.
-powerlimit\plclient,*,,,22621,Only NI: Not supported on NI.
-powerlimit\plpolicy,*,,,22621,Only NI: Not supported on NI.
-general\pcidrv,*,,26100,,"failure introduced in VS17.14, suppressed until fix"
-serial\serial,*,,26100,,"failure introduced in VS17.14, suppressed until fix"
-network\wlan\wdi,*,,26100,,"failure introduced in VS17.14, suppressed until fix"
-tools\kasan\samples\kasandemo-wdm,*|x64,,26100,,"failure introduced in VS17.14, suppressed until fix"
+Path,Configurations,TargetVersions,MinBuild,MaxBuild,MinNtTargetVersion,MaxNtTargetVersion,Reason
+audio\acx\samples\audiocodec\driver,*,,,22621,,,Only NI: error C1083: Cannot open include file: 'acx.h': No such file or directory
+general\dchu\osrfx2_dchu_extension_loose,*|x64,,,22621,,,Only NI: Only x64: Fails to build
+general\dchu\osrfx2_dchu_extension_tight,*|x64,,,22621,,,Only NI: Only x64: Fails to build
+network\trans\WFPSampler,Debug|ARM64,,,22621,,,Only NI: Only ARM: Fails to build on EWDK 22621 with VS 17.1.5 - CallingConvention=StdCall not supported
+prm,*,,,22621,,,Only NI: Not supported on NI.
+powerlimit\plclient,*,,,22621,,,Only NI: Not supported on NI.
+powerlimit\plpolicy,*,,,22621,,,Only NI: Not supported on NI.
+general\pcidrv,*,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+serial\serial,*,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+network\wlan\wdi,*,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+tools\kasan\samples\kasandemo-wdm,*|x64,,26100,,,,"failure introduced in VS17.14, suppressed until fix"
+audio\sysvad,*,,,,,22000,_NT_TARGET_VERSION: KSJACK_DESCRIPTION3 undeclared; audio jack descriptor v3 was added in 22H2 (10.0.22621)
+network\netadaptercx\netvadapter,*,,,,,22621,_NT_TARGET_VERSION: requests an NDIS/DDI version newer than the linked library (C1189 wrong NDIS or DDI version)
+network\wlan\wificx,*,,,,,22621,_NT_TARGET_VERSION: requests an NDIS/DDI version newer than the linked library (C1189 wrong NDIS or DDI version)
+powerlimit\plclient,*,,,,,22621,_NT_TARGET_VERSION: POWER_LIMIT_ATTRIBUTES not declared in the older library (C2061)
+powerlimit\plpolicy,*,,,,,22621,_NT_TARGET_VERSION: POWER_LIMIT_ATTRIBUTES not declared in the older library (C2061)
+storage\class\classpnp,Debug|*,,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug only
+storage\miniports\storahci,Debug|*,,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug only
+storage\msdsm,Debug|x64,,,,,22621,_NT_TARGET_VERSION: STOR_ADDRESS_TYPE_NVME undeclared in the older library (C2065); Debug|x64 only


### PR DESCRIPTION
This pull request updates the `CodeQL Analysis` GitHub Actions workflow to improve efficiency and reduce analysis time, especially for large pushes. The workflow now distinguishes between pull request and push/scheduled events: PRs analyze only changed samples in a single job, while pushes and scheduled runs use sharding to build and analyze all samples in parallel across four jobs. Several steps and dependencies have also been updated.

**Workflow structure improvements:**

* Split the workflow into two jobs: `analyze-pr` (for pull requests, builds only changed samples in a single job) and `analyze` (for pushes/schedules, splits all samples across 4 parallel shards for faster analysis). [[1]](diffhunk://#diff-37a0da05299a2538ff65e69c80d359d892a4194838df66f6de59e2c410896bb2L27-R35) [[2]](diffhunk://#diff-37a0da05299a2538ff65e69c80d359d892a4194838df66f6de59e2c410896bb2L38-R137)

**Performance and efficiency:**

* For push/schedule events, added logic to divide the build and analysis of all samples into 4 shards, each running in parallel with `ThrottleLimit 1` to maintain accurate CodeQL tracing.
* For pull requests, added a step to detect changed files and build only those samples, avoiding unnecessary builds.

**Dependency and version updates:**

* Updated `github/codeql-action/init` and `github/codeql-action/analyze` to use version `v4` instead of `v3` for improved features and support.

**Documentation:**

* Added detailed comments at the top of the workflow file explaining the new sharding approach and the distinction between PR and push/schedule jobs.