### PR TITLE
Potentially uninitialized variables in bindview

### DIFF
--- a/network/config/bindview/BINDVIEW.CPP
+++ b/network/config/bindview/BINDVIEW.CPP
@@ -1444,7 +1444,7 @@ VOID ShowComponentMenu (HWND hwndOwner,
                         LPARAM lParam)
 {
     ULONG   ulSelection;
-    POINT   pt;
+    POINT   pt{};
 
     GetCursorPos( &pt );
     ulSelection = (ULONG)TrackPopupMenu( hComponentSubMenu,
@@ -1496,7 +1496,7 @@ VOID ShowBindingPathMenu (HWND hwndOwner,
 {
     MENUITEMINFOW  menuItemInfo;
     ULONG   ulSelection;
-    POINT   pt;
+    POINT   pt{};
 
     //
     // Build the shortcut menu depending on whether path is
@@ -1787,7 +1787,7 @@ HTREEITEM AddToTreeEx (HWND hwndTree,
     LPWSTR           lpszId;
     GUID             guidClass;
     BOOL             fEnabled;
-    ULONG            ulStatus;
+    ULONG            ulStatus{};
     HTREEITEM        hTreeItem;
     TV_INSERTSTRUCTW tvInsertStruc;
     HRESULT          hr;


### PR DESCRIPTION
Running the [Windows Driver Developer Supplemental Tools](https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools) on bindview with "recommended" and "must-fix" codeql queries results in these warnings in `bindview.cpp`:

- 1449 The status of this call to externally defined (SAL) GetCursorPos is not checked, potentially leaving pt uninitialized.
- 1528 The status of this call to externally defined (SAL) GetCursorPos is not checked, potentially leaving pt uninitialized.
- 1825 The status of this call to externally defined (SAL) GetDeviceStatus is not checked, potentially leaving ulStatus uninitialized.

These changes eliminate these warnings by initializing the variables mentioned.