### PR TITLE
Potentially uninitialized variable in ndisbind.c

### DIFF
--- a/network/ndis/ndisprot/6x/sys/debug.c
+++ b/network/ndis/ndisprot/6x/sys/debug.c
@@ -43,7 +43,7 @@ ndisprotAuditAllocMem(
 )
 {
 	PVOID				pBuffer;
-	PNPROTD_ALLOCATION	pAllocInfo;
+	PNPROTD_ALLOCATION	pAllocInfo = NULL;
 
 	if (!ndisprotdInitDone)
 	{
@@ -88,7 +88,7 @@ ndisprotAuditAllocMem(
 			ndisprotdMemoryTail->Next = pAllocInfo;
 		}
 		ndisprotdMemoryTail = pAllocInfo;
-		
+
 		ndisprotdAllocCount++;
 		NdisReleaseSpinLock(&(ndisprotdMemoryLock));
 	}
@@ -295,9 +295,9 @@ ndisprotFreeDbgLock(
     VOID
     )
 {
-    
+
     ASSERT(ndisprotdSpinLockInitDone == 1);
-    
+
     ndisprotdSpinLockInitDone = 0;
     NdisFreeSpinLock(&(ndisprotdLockLock));
 }

--- a/network/ndis/ndisprot/6x/sys/ndisbind.c
+++ b/network/ndis/ndisprot/6x/sys/ndisbind.c
@@ -70,7 +70,7 @@ Return Value:
 
 --*/
 {
-    PNDISPROT_OPEN_CONTEXT          pOpenContext;
+    PNDISPROT_OPEN_CONTEXT          pOpenContext = NULL;
     NDIS_STATUS                     Status;
 
     UNREFERENCED_PARAMETER(ProtocolDriverContext);

--- a/network/ndis/ndisprot/6x/test/prottest.c
+++ b/network/ndis/ndisprot/6x/test/prottest.c
@@ -379,6 +379,7 @@ GetSrcMac(
                 BytesReturned));
 
 #pragma warning(suppress:6202) // buffer overrun warning - enough space allocated in QueryBuffer
+        // codeql[cpp/buffer-overflow]
         memcpy(pSrcMacAddr, pQueryOid->Data, MAC_ADDR_LEN);
     }
     else

--- a/network/ndis/ndisprot_kmdf/60/debug.c
+++ b/network/ndis/ndisprot_kmdf/60/debug.c
@@ -39,7 +39,7 @@ ndisprotAuditAllocMem(
 )
 {
     PVOID                pBuffer;
-    PNPROTD_ALLOCATION    pAllocInfo;
+    PNPROTD_ALLOCATION   pAllocInfo = NULL;
 
     if (!ndisprotdInitDone)
     {

--- a/network/ndis/ndisprot_kmdf/60/ndisbind.c
+++ b/network/ndis/ndisprot_kmdf/60/ndisbind.c
@@ -61,14 +61,17 @@ Routine Description:
 
 Arguments:
 
+    ProtocolDriverContext - handle to the protocol driver context
+    BindContext - handle to the bind context provided by NDIS
+    BindParameters - parameters describing the adapter to which we are binding
 
 Return Value:
 
-    None
+    NDIS_STATUS_SUCCESS if successful, failure code otherwise.
 
 --*/
 {
-    PNDISPROT_OPEN_CONTEXT          pOpenContext;
+    PNDISPROT_OPEN_CONTEXT          pOpenContext = NULL;
     NDIS_STATUS                     Status;
     WDF_IO_QUEUE_CONFIG             queueConfig;
     NTSTATUS                        ntStatus;
@@ -1334,9 +1337,9 @@ Return Value:
     while (FALSE);
 
     DEBUGP(DL_LOUD, ("ValidateOpenAndDoReq: Open %p/%x, OID %x, Status %x\n",
-						pOpenContext, 
-						pOpenContext == NULL ? 0 : pOpenContext->Flags, 
-						Oid, 
+						pOpenContext,
+						pOpenContext == NULL ? 0 : pOpenContext->Flags,
+						Oid,
 						Status));
 
     return (Status);


### PR DESCRIPTION
These changes eliminate the warnings about uninitialized variables under network\ndis.
A macro was also added to prottest.c to suppress a (false) buffer overrun.
Some trailing spaces were removed.