### PR TITLE
netvmini/rssv2: fix mixed-width comparison in processor lookup loop

### DIFF
--- a/network/ndis/netvmini/6x/rssv2.c
+++ b/network/ndis/netvmini/6x/rssv2.c
@@ -210,7 +210,7 @@ Return Value:
 
 --*/
 {
-    UINT8 index;
+    ULONG index;
     PNDIS_RSS_PROCESSOR processor;
 
     for (index = 0; 
@@ -222,7 +222,7 @@ Return Value:
         if ((processor->ProcNum.Group == ProcessorNumber.Group) && 
             (processor->ProcNum.Number == ProcessorNumber.Number))
         {
-            return index;
+            return (UINT8)index;
         }
     }
 


### PR DESCRIPTION
Summary
This PR addresses a static-analysis warning in rssv2.c related to comparing values of different integer widths in a loop condition.

Changes
- Updated the loop index type in NICSetRSSv2FindProcessorInRssSet from UINT8 to ULONG to match RssProcessorCount width.
- Added an explicit cast when returning the found index: return (UINT8)index; to preserve the function’s return type and behavior.

Why
Using matching integer widths in loop comparisons avoids analyzer warnings and reduces risk of subtle boundary issues.

Impact
No functional behavior change is intended; this is a type-safety and code-quality fix for warning cleanup.