### PR TITLE
NDIS: Harden QoS bytes calculation in netvmini control path

### DIFF
--- a/network/ndis/netvmini/6x/ctrlpath.c
+++ b/network/ndis/netvmini/6x/ctrlpath.c
@@ -20,6 +20,7 @@ Abstract:
 
 
 #include "netvmin6.h"
+#include <ntintsafe.h>
 #include "ctrlpath.tmh"
 
 
@@ -1671,6 +1672,9 @@ Return Value:
 
     do
     {
+        ULONG ClassificationBytes = 0;
+        ULONG BytesRead = 0;
+
         //
         // Verify that the request matches our requirements.
         //
@@ -1681,8 +1685,18 @@ Return Value:
         //
         // Request is well formed, set bytes read.
         //
-        Method->BytesRead = NDIS_SIZEOF_QOS_PARAMETERS_REVISION_1 +
-                            Params->NumClassificationElements * Params->ClassificationElementSize;
+        if (!NT_SUCCESS(RtlULongMult(Params->NumClassificationElements,
+                                     Params->ClassificationElementSize,
+                                     &ClassificationBytes)) ||
+            !NT_SUCCESS(RtlULongAdd(NDIS_SIZEOF_QOS_PARAMETERS_REVISION_1,
+                                    ClassificationBytes,
+                                    &BytesRead)))
+        {
+            Status = NDIS_STATUS_INVALID_LENGTH;
+            break;
+        }
+
+        Method->BytesRead = BytesRead;
 
         Status = SetQOSParameters(Adapter, Params);
         if (Status != NDIS_STATUS_SUCCESS)


### PR DESCRIPTION
This fixes:
CodeQL Scanning Alert in network/ndis/netvmini/6x/ctrlpath.c - Multiplication result converted to larger type

Summary:
- Replaced direct size arithmetic in NICSetQOSParameters with checked integer-safe operations.
- Added overflow handling for classification table size computation:
- Multiply NumClassificationElements × ClassificationElementSize via RtlULongMult.
- Add the revision header size via RtlULongAdd.
- Return NDIS_STATUS_INVALID_LENGTH when either checked operation fails, instead of relying on unchecked arithmetic.