### PR TITLE
Removed trailing spaces under config and modem

### DIFF
--- a/network/config/bindview/BINDING.CPP
+++ b/network/config/bindview/BINDING.CPP
@@ -10,7 +10,7 @@
 //              o How to enumerate binding interfaces.
 //              o How to enable/disable bindings.
 //
-//  Notes:      
+//  Notes:
 //
 //  Author:     Alok Sinha    15-May-01
 //
@@ -183,7 +183,7 @@ VOID WriteBindingPath (FILE *fp,
                 fwprintf( fp, L"\n%s", lpszName );
             }
         }
-  
+
         ReleaseRef( pencbp );
     }
     else {
@@ -389,7 +389,7 @@ VOID ListBindings (INetCfgComponent *pncc,
     HTREEITEM                   hTreeItem;
     ULONG                       ulIndex;
     HRESULT                     hr;
-  
+
     hr = HrGetBindingPathEnum( pncc,
                                EBP_BELOW,
                                &pencbp );
@@ -429,7 +429,7 @@ VOID ListBindings (INetCfgComponent *pncc,
 
             ulIndex++;
         }
-  
+
         ReleaseRef( pencbp );
     }
     else {
@@ -533,7 +533,7 @@ VOID ListInterfaces (INetCfgBindingPath *pncbp,
 //
 // Function:  HandleBindingPathOperation
 //
-// Purpose:   
+// Purpose:
 //
 // Arguments:
 //    hwndOwner    [in]  Owner window.
@@ -778,7 +778,7 @@ FindBindingPath (
                              &pncc );
 
     if ( hr == S_OK ) {
-     
+
         hr = HrGetBindingPathEnum( pncc,
                                    EBP_BELOW,
                                    &pencbp );

--- a/network/config/bindview/BINDVIEW.H
+++ b/network/config/bindview/BINDVIEW.H
@@ -7,7 +7,7 @@
 //
 //  Contents:   Function Prototypes
 //
-//  Notes:      
+//  Notes:
 //
 //  Author:     Alok Sinha    15-May-01
 //

--- a/network/config/bindview/NetCfgAPI.cpp
+++ b/network/config/bindview/NetCfgAPI.cpp
@@ -248,7 +248,7 @@ HRESULT HrInstallNetComponent (IN INetCfg *pnc,
             {
                 hr = E_OUTOFMEMORY;
                 break;
-            }               
+            }
             ZeroMemory(DirWithDrive, (_MAX_DRIVE + _MAX_DIR) * sizeof(WCHAR));
 
             //
@@ -329,7 +329,7 @@ HRESULT HrInstallNetComponent (IN INetCfg *pnc,
     {
         CoTaskMemFree(DirWithDrive);
         DirWithDrive = NULL;
-    }    
+    }
 
     return hr;
 }

--- a/network/config/bindview/NetCfgAPI.h
+++ b/network/config/bindview/NetCfgAPI.h
@@ -7,7 +7,7 @@
 //
 //  Contents:   Functions Prototypes
 //
-//  Notes:      
+//  Notes:
 //
 //  Author:     Alok Sinha    15-May-01
 //

--- a/network/config/bindview/RESOURCE.H
+++ b/network/config/bindview/RESOURCE.H
@@ -32,7 +32,7 @@
 #define IDI_DISABLE                     40007
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        109

--- a/network/modem/fakemodem/driver.c
+++ b/network/modem/fakemodem/driver.c
@@ -232,7 +232,7 @@ Return Value:
                              &defQueue // pointer to default queue
                              );
     __analysis_assume(queueConfig.EvtIoStop == 0);
-	
+
     if (!NT_SUCCESS (status)) {
 
         //
@@ -256,7 +256,7 @@ Return Value:
                               &fmDeviceData->FmReadQueue
                              );
     __analysis_assume(queueConfig.EvtIoStop == 0);
-	
+
     if (!NT_SUCCESS (status)) {
         KdPrint( ("WdfIoQueueCreate failed 0x%x\n", status));
         return status;
@@ -276,7 +276,7 @@ Return Value:
                               &fmDeviceData->FmMaskWaitQueue
                              );
     __analysis_assume(queueConfig.EvtIoStop == 0);
-	
+
     if (!NT_SUCCESS (status)) {
         KdPrint( ("WdfIoQueueCreate failed 0x%x\n", status));
         return status;


### PR DESCRIPTION
This PR performs a whitespace-only cleanup by removing trailing spaces/tabs from source files under directories:
	• network\config
	• network\modem

No functional logic changes were introduced.

What Changed
	1. Removed end-of-line trailing whitespace in text files.
	2. Kept file encoding and line endings intact by applying byte-preserving edits.

Risk / Impact
	1. Low risk: formatting-only change.
	2. No API, behavior, or build configuration changes intended.