### PR TITLE
Clean up comment and header metadata across network samples

### DIFF
--- a/network/config/bindview/BINDVIEW.CPP
+++ b/network/config/bindview/BINDVIEW.CPP
@@ -1563,7 +1563,7 @@ VOID ShowBindingPathMenu (HWND hwndOwner,
 //    lpdwItemType [out] Type, binding path or network component.
 //    fEnabled     [out] TRUE if the binding path or component is enabled.
 //
-// Returns:   TRUE on sucess.
+// Returns:   TRUE on success.
 //
 // Notes:
 //

--- a/network/modem/fakemodem/driver.c
+++ b/network/modem/fakemodem/driver.c
@@ -15,8 +15,8 @@ Abstract:
 
     This is a simple form of function driver for fakemodem device. The driver
     doesn't handle any PnP and Power events because the framework provides
-    default behaviour for those events. This driver has enough support to
-    allow an user application (toast/notify.exe) to open the device
+    default behavior for those events. This driver has enough support to
+    allow a user application (toast/notify.exe) to open the device
     interface registered by the driver and send read, write or ioctl requests.
 
 Environment:

--- a/network/modem/fakemodem/ioctl.c
+++ b/network/modem/fakemodem/ioctl.c
@@ -689,7 +689,7 @@ Return Value:
         case IOCTL_SERIAL_SET_HANDFLOW:
         case IOCTL_SERIAL_RESET_DEVICE: {
             //
-            // NOTE: The application expects STATUS_SUCCESS for these ioctsl.
+            // NOTE: The application expects STATUS_SUCCESS for these ioctls.
             //  so don't merge this with default.
             //
             break;

--- a/network/modem/fakemodem/readwrit.c
+++ b/network/modem/fakemodem/readwrit.c
@@ -49,8 +49,8 @@ Arguments:
 
     Length - Length of the IO operation
                  The default property of the queue is to not dispatch
-                 zero lenght read & write requests to the driver and
-                 complete is with status success. So we will never get
+                 zero length read & write requests to the driver and
+                 complete it with status success. So we will never get
                  a zero length request.
 
 Return Value:
@@ -117,8 +117,8 @@ Arguments:
 
     Length - Length of the IO operation
                  The default property of the queue is to not dispatch
-                 zero lenght read & write requests to the driver and
-                 complete is with status success. So we will never get
+                 zero length read & write requests to the driver and
+                 complete it with status success. So we will never get
                  a zero length request.
 
 Return Value:
@@ -193,8 +193,8 @@ Arguments:
 
     Length - Length of the IO operation
                  The default property of the queue is to not dispatch
-                 zero lenght read & write requests to the driver and
-                 complete is with status success. So we will never get
+                 zero length read & write requests to the driver and
+                 complete it with status success. So we will never get
                  a zero length request.
 
 Return Value:

--- a/network/modem/fakemodem/readwrit.c
+++ b/network/modem/fakemodem/readwrit.c
@@ -9,7 +9,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 Module Name:
 
-    ioctl.c
+    readwrit.c
 
 Abstract:
 

--- a/network/modem/fakemodem/readwrit.c
+++ b/network/modem/fakemodem/readwrit.c
@@ -15,8 +15,8 @@ Abstract:
 
     This is a simple form of function driver for Fm device. The driver
     doesn't handle any PnP and Power events because the framework provides
-    default behaviour for those events. This driver has enough support to
-    allow an user application (toast/notify.exe) to open the device
+    default behavior for those events. This driver has enough support to
+    allow a user application (toast/notify.exe) to open the device
     interface registered by the driver and send read, write or ioctl requests.
 
 Environment:

--- a/network/ndis/extension/base/SxApi.h
+++ b/network/ndis/extension/base/SxApi.h
@@ -825,7 +825,7 @@ Arguments:
     ExtensionContext - The extension context allocated in SxExtCreateSwitch
                        for the switch
 
-    SwitchProperty - the property to be deleted
+    PortProperty - the property to be deleted
 
 Return Value:
     TRUE - if the policy is not consumed by this extension
@@ -982,7 +982,15 @@ Arguments:
     ExtensionContext - The extension context allocated in SxExtCreateSwitch
                        for the switch
 
-    NicOidRequest - the OID buffer, encapsulated with source/destination info
+    OidRequest - the OID buffer, encapsulated with source/destination info
+
+    SourcePortId - the source PortId of the OID completion
+
+    SourceNicIndex - the source NicIndex of the OID completion
+
+    DestinationPortId - the destination PortId of the OID completion
+
+    DestinationNicIndex - the destination NicIndex of the OID completion
 
     Status - the status the OID completed with
 

--- a/network/ndis/extension/base/SxApi.h
+++ b/network/ndis/extension/base/SxApi.h
@@ -58,7 +58,7 @@ SxExtInitialize
 
 Routine Description:
     This function is called from the SxBase Library during DriverEntry.
-    An extension should allocate/initalize all global data in this function.
+    An extension should allocate/initialize all global data in this function.
 
 Arguments:
     NULL
@@ -410,7 +410,7 @@ SxExtDeleteNic
 
 Routine Description:
     This function is called to delete a NIC from a switch.
-    No futher traffic/control will be recieved for this NIC.
+    No further traffic/control will be received for this NIC.
 
 Arguments:
     Switch - the Switch context
@@ -438,7 +438,7 @@ SxExtTeardownPort
 
 Routine Description:
     This function is called to start deletion of a port on a switch.
-    Upon recieving this call, no further references may be taken
+    Upon receiving this call, no further references may be taken
     on the given port.
 
 Arguments:
@@ -467,7 +467,7 @@ SxExtDeletePort
 
 Routine Description:
     This function is called to finish deletion of a port on a switch.
-    Upon recieving this call, no traffic/control will be recieved
+    Upon receiving this call, no traffic/control will be received
     for this port.
 
 Arguments:

--- a/network/ndis/extension/base/SxApi.h
+++ b/network/ndis/extension/base/SxApi.h
@@ -918,7 +918,7 @@ SxExtQueryPortFeatureStatus(
 SxExtProcessNicRequest
 
 Routine Description:
-    This function is called upon the reciept of an OID_SWITCH_NIC_REQUEST
+    This function is called upon the receipt of an OID_SWITCH_NIC_REQUEST
     to the extension.
     If an extension wishes to redirect the OID, it must return a valid
     DestinationPortId and DestinationNicIndex, which it has taken a
@@ -1016,12 +1016,12 @@ SxExtProcessNicRequestComplete(
 SxExtProcessNicStatus
 
 Routine Description:
-    This function is called upon the reciept of an NDIS_STATUS_SWITCH_NIC_STATUS
+    This function is called upon the receipt of an NDIS_STATUS_SWITCH_NIC_STATUS
     to the extension.
     If the extension wishes to modify the status indication, it should
     send its own status indication using NdisFIndicateStatus and return a
     failure status.
-    If the extension wishes to drop the status indiction, it should return
+    If the extension wishes to drop the status indication, it should return
     failure status, though this should be done very sparingly and carefully.
 
     !! This function should only be used by forwarding extensions. !!

--- a/network/ndis/extension/base/SxBase.c
+++ b/network/ndis/extension/base/SxBase.c
@@ -348,7 +348,7 @@ SxNdisDetach(
     ExFreePool(switchObject);
 
     //
-    // Alway return success.
+    // Always return success.
     //
     DEBUGP(DL_TRACE, ("<===SxDetach Successfully\n"));
 

--- a/network/ndis/extension/base/SxBase.h
+++ b/network/ndis/extension/base/SxBase.h
@@ -4,7 +4,7 @@ Copyright (c) Microsoft Corporation. All Rights Reserved.
 
 Module Name:
 
-    SxBase.c
+    SxBase.h
 
 Abstract:
 

--- a/network/ndis/extension/base/SxLibrary.h
+++ b/network/ndis/extension/base/SxLibrary.h
@@ -261,7 +261,7 @@ Routine Description:
     This function is called to get the current array
     of ports.
 
-    NOTE: It is necessary to synchonize this with SxExtPortCreate
+    NOTE: It is necessary to synchronize this with SxExtPortCreate
     and SxExtPortTeardown.
 
 Arguments:
@@ -292,7 +292,7 @@ Routine Description:
     This function is called to get the current array
     of NICs.
 
-    NOTE: It is necessary to synchonize this with SxExtNicConnect
+    NOTE: It is necessary to synchronize this with SxExtNicConnect
     and SxExtNicDisconnect.
 
 Arguments:
@@ -322,7 +322,7 @@ Routine Description:
     This function is called to get the current array of the switch
     property queried.
 
-    NOTE: It is necessary to synchonize this with SxExtAddSwitchProperty
+    NOTE: It is necessary to synchronize this with SxExtAddSwitchProperty
     and SxExtDeleteSwitchProperty.
 
 Arguments:
@@ -358,7 +358,7 @@ Routine Description:
     This function is called to get the current array of the switch
     property queried.
 
-    NOTE: It is necessary to synchonize this with SxExtAddPortProperty
+    NOTE: It is necessary to synchronize this with SxExtAddPortProperty
     and SxExtDeletePortProperty.
 
 Arguments:

--- a/network/ndis/extension/base/SxLibrary.h
+++ b/network/ndis/extension/base/SxLibrary.h
@@ -23,7 +23,7 @@ Routine Description:
     This function is called to forward NBLs on ingress.
     The extension MUST call this function, or call
     SxLibCompleteNetBufferListsIngress for every NBL in NetBufferLists,
-    recieved in SxExtStartNetBufferListsIngress.
+    received in SxExtStartNetBufferListsIngress.
 
     This function can also be called to inject NBLs.
     If there are NBLs in NetBufferLists that are initiated by the
@@ -62,7 +62,7 @@ Routine Description:
     This function is called to forward NBLs on egress.
     The extension MUST call this function, or call
     SxLibCompleteNetBufferListsEgress for every NBL in NetBufferLists
-    recieved in SxExtStartNetBufferListsEgress.
+    received in SxExtStartNetBufferListsEgress.
 
 Arguments:
 
@@ -94,7 +94,7 @@ SxLibCompleteNetBufferListsEgress
 
 Routine Description:
     This function is called to complete NBLs on egress.
-    The extension MUST call this function for all NBLs recieved
+    The extension MUST call this function for all NBLs received
     in SxExtStartCompleteNetBufferListsEgress.
 
 Arguments:
@@ -124,7 +124,7 @@ SxLibCompleteNetBufferListsIngress
 Routine Description:
     This function is called to complete NBLs on ingress.
     The extension MUST call this function, or
-    SxLibCompletedInjectedNetBufferLists for all NBLs recieved in
+    SxLibCompletedInjectedNetBufferLists for all NBLs received in
     SxExtStartCompleteNetBufferListsEgress.
 
 Arguments:

--- a/network/ndis/extension/base/SxLibrary.h
+++ b/network/ndis/extension/base/SxLibrary.h
@@ -190,7 +190,7 @@ Routine Description:
 
 Arguments:
 
-    Switch - pointer to our switch object.
+    SxSwitch - pointer to our switch object.
 
     RequestType - NdisRequest[Set|Query|method]Information.
 
@@ -297,7 +297,7 @@ Routine Description:
 
 Arguments:
 
-    Switch - the Switch context
+    SxSwitch - the Switch context
 
     NicArray - the returned NIC array
 
@@ -332,8 +332,6 @@ Arguments:
     PropertyType - the PropertyType to query for
 
     PropertyId - the GUID of the property (from mof file)
-
-    PropertyVersion - the version of the property
 
     SwitchPropertyEnumParameters - the returned property enum
 

--- a/network/ndis/filter/filteruser.h
+++ b/network/ndis/filter/filteruser.h
@@ -1,5 +1,5 @@
 //
-//    Copyright (C) Microsoft.  All rights reserved.
+//    Copyright (C) Microsoft Corporation.  All rights reserved.
 //
 #ifndef __FILTERUSER_H__
 #define __FILTERUSER_H__

--- a/network/ndis/filter/flt_dbg.c
+++ b/network/ndis/filter/flt_dbg.c
@@ -4,7 +4,7 @@ Copyright (c) 2001  Microsoft Corporation
 
 Module Name:
 
-    debug.c
+    flt_dbg.c
 
 Abstract:
 

--- a/network/ndis/filter/flt_dbg.h
+++ b/network/ndis/filter/flt_dbg.h
@@ -4,7 +4,7 @@ Copyright (c) 2001  Microsoft Corporation
 
 Module Name:
 
-    debug.h
+    flt_dbg.h
 
 Abstract:
 
@@ -16,9 +16,6 @@ Revision History:
 Notes:
 
 --*/
-
-// disable warnings
-
 
 #ifndef _FILTDEBUG__H
 #define _FILTDEBUG__H

--- a/network/ndis/mux/driver/60/protocol.c
+++ b/network/ndis/mux/driver/60/protocol.c
@@ -1,5 +1,5 @@
 /*++
-Copyright(c) 1992-2000  Microsoft Corporation
+Copyright (c) 1992-2000  Microsoft Corporation
 
 Module Name:
 

--- a/network/ndis/ndisprot/6x/sys/60/ndisprot60.rc
+++ b/network/ndis/ndisprot/6x/sys/60/ndisprot60.rc
@@ -9,7 +9,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 Module Name:
 
-    ndisprot.rc
+    ndisprot60.rc
 
 Abstract:
 

--- a/network/ndis/ndisprot/6x/sys/630/ndisprot630.rc
+++ b/network/ndis/ndisprot/6x/sys/630/ndisprot630.rc
@@ -9,7 +9,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 Module Name:
 
-    ndisprot.rc
+    ndisprot630.rc
 
 Abstract:
 

--- a/network/ndis/ndisprot/6x/sys/protuser.h
+++ b/network/ndis/ndisprot/6x/sys/protuser.h
@@ -4,7 +4,7 @@ Copyright (c) 2000  Microsoft Corporation
 
 Module Name:
 
-    nuiouser.h
+    protuser.h
 
 Abstract:
 

--- a/network/ndis/ndisprot_kmdf/60/protuser.h
+++ b/network/ndis/ndisprot_kmdf/60/protuser.h
@@ -4,7 +4,7 @@ Copyright (c) 2000  Microsoft Corporation
 
 Module Name:
 
-    nuiouser.h
+    protuser.h
 
 Abstract:
 

--- a/network/ndis/ndisprot_kmdf/60/send.c
+++ b/network/ndis/ndisprot_kmdf/60/send.c
@@ -37,10 +37,10 @@ Arguments:
 
     Queue - Default queue handle
     Request - Handle to the read/write request
-    Lenght - Length of the data buffer associated with the request.
+    Length - Length of the data buffer associated with the request.
                  The default property of the queue is to not dispatch
-                 zero lenght read & write requests to the driver and
-                 complete is with status success. So we will never get
+                 zero length read & write requests to the driver and
+                 complete it with status success. So we will never get
                  a zero length request.
 
 Return Value:

--- a/network/ndis/netvmini/6x/60/netvmini60.rc
+++ b/network/ndis/netvmini/6x/60/netvmini60.rc
@@ -9,7 +9,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 Module Name:
 
-    netvmini.rc
+    netvmini60.rc
 
 Abstract:
 

--- a/network/ndis/netvmini/6x/620/netvmini620.rc
+++ b/network/ndis/netvmini/6x/620/netvmini620.rc
@@ -9,7 +9,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 Module Name:
 
-    netvmini.rc
+    netvmini620.rc
 
 Abstract:
 

--- a/network/ndis/netvmini/6x/adapter.c
+++ b/network/ndis/netvmini/6x/adapter.c
@@ -552,7 +552,7 @@ Routine Description:
     send requests must be completed, and new requests must be rejected with
     NDIS_STATUS_PAUSED.
 
-    Once all sends have been completed and all recieve NBLs have returned to
+    Once all sends have been completed and all receive NBLs have returned to
     the miniport, the miniport enters the Paused state.
 
     While paused, the miniport can still service interrupts from the hardware
@@ -2281,7 +2281,7 @@ Arguments:
 
 Return Value:
 
-    NDIS_STATUS_SUCCESS if reference was acquired succesfully.
+    NDIS_STATUS_SUCCESS if reference was acquired successfully.
     NDIS_STATUS_ADAPTER_NOT_READY if the adapter state is such that we should not acquire new references to resources
 
 --*/

--- a/network/ndis/netvmini/6x/adapter.h
+++ b/network/ndis/netvmini/6x/adapter.h
@@ -52,14 +52,14 @@ typedef struct _MP_ADAPTER_RECEIVE_DPC
 {
     LIST_ENTRY Entry;
     //
-    // Kernel DPC used for recieve
+    // Kernel DPC used for receive
     //
     KDPC Dpc;
     USHORT ProcessorGroup;
     ULONG ProcessorNumber;
 
     //
-    // Tracks which receive blocks need to be recieved on this DPC.
+    // Tracks which receive blocks need to be received on this DPC.
     //
     BOOLEAN RecvBlock[NIC_SUPPORTED_NUM_QUEUES];
     volatile LONG RecvBlockCount;

--- a/network/ndis/netvmini/6x/datapath.c
+++ b/network/ndis/netvmini/6x/datapath.c
@@ -755,7 +755,7 @@ Arguments:
 
 Return Value:
 
-    NDIS_STATUS_SUCCESS if reference was acquired succesfully.
+    NDIS_STATUS_SUCCESS if reference was acquired successfully.
     NDIS_STATUS_ADAPTER_NOT_READY if the adapter state is such that we should not acquire new references to resources
 
 --*/

--- a/network/ndis/netvmini/6x/miniport.h
+++ b/network/ndis/netvmini/6x/miniport.h
@@ -19,7 +19,7 @@ Abstract:
        1.  Set the correct driver version number for your versioning scheme.
        2.  Create unique memory allocation tags.
 
- --*/
+--*/
 
 
 #ifndef _MINIPORT_H

--- a/network/ndis/netvmini/6x/trace.h
+++ b/network/ndis/netvmini/6x/trace.h
@@ -14,7 +14,7 @@ Module Name:
 Abstract:
 
 
- --*/
+--*/
 
 
 #ifndef _TRACE_H

--- a/network/ndis/netvmini/6x/vmq.c
+++ b/network/ndis/netvmini/6x/vmq.c
@@ -3104,7 +3104,7 @@ Routine Description:
 Arguments:
 
     Adapter                - Pointer to our adapter
-    Rcb                    - RCB to queue for recieve
+    Rcb                    - RCB to queue for receive
 
 Return Value:
 


### PR DESCRIPTION
This PR cleans up documentation and headers across samples under config, modem, and ndis.

**Summary**
    - Fixes typos in comments and doc blocks, including return-value descriptions and general wording updates.
    - Corrects top-of-file metadata such as Module Name entries where the documented filename did not match the actual file.
    - Fixes malformed or incomplete copyright headers in a small number of files.
    - Aligns function comment parameter names with actual signatures in the NDIS extension headers.
    - Applies minor presentation cleanup in a few header/comment blocks.

**Impact**
    - No intended functional or logic changes.
    - Changes are limited to comments, documentation text, and file/header metadata consistency.