### PR TITLE
Fix C4430 warning in avshws.h

### DIFF
--- a/avstream/avshws/avshws.h
+++ b/avstream/avshws/avshws.h
@@ -56,7 +56,7 @@ extern "C" {
 #define DEBUGLVL_TERSE 1
 #define DEBUGLVL_ERROR 0
 
-const DebugLevel = DEBUGLVL_TERSE;
+const int DebugLevel = DEBUGLVL_TERSE;
 
 #if (DBG)
 #define _DbgPrintF(lvl, strings) \


### PR DESCRIPTION
This was caught internally when trying to enable [MSVC warning C4430](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4430).